### PR TITLE
Import GaleNetPipeline directly in package init

### DIFF
--- a/src/galenet/__init__.py
+++ b/src/galenet/__init__.py
@@ -21,11 +21,8 @@ from .data import (
     IBTrACSLoader,
 )
 
-# Main pipeline (will be implemented in later phases)
-try:
-    from .inference.pipeline import GaleNetPipeline
-except ImportError:
-    GaleNetPipeline = None
+# Main pipeline
+from .inference.pipeline import GaleNetPipeline
 
 __all__ = [
     # Version info


### PR DESCRIPTION
## Summary
- Remove try/except ImportError guard and import `GaleNetPipeline` directly in `galenet` package init
- Keep `GaleNetPipeline` in `__all__` to expose pipeline to consumers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68980a06b7b08326ac17bf7b1a342930