### PR TITLE
Add evaluation metrics and baselines with tests

### DIFF
--- a/src/galenet/evaluation/__init__.py
+++ b/src/galenet/evaluation/__init__.py
@@ -1,0 +1,25 @@
+"""Evaluation utilities for GaleNet."""
+
+from .metrics import (
+    track_error,
+    along_track_error,
+    cross_track_error,
+    intensity_mae,
+    compute_metrics,
+)
+from .baselines import (
+    run_baselines,
+    persistence_baseline,
+    cliper5_baseline,
+)
+
+__all__ = [
+    "track_error",
+    "along_track_error",
+    "cross_track_error",
+    "intensity_mae",
+    "compute_metrics",
+    "run_baselines",
+    "persistence_baseline",
+    "cliper5_baseline",
+]

--- a/src/galenet/evaluation/baselines.py
+++ b/src/galenet/evaluation/baselines.py
@@ -1,0 +1,63 @@
+"""Baseline forecast methods for evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Sequence
+
+import numpy as np
+import yaml
+
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "default_config.yaml"
+with open(_CONFIG_PATH) as _cfg:
+    DEFAULT_BASELINES: Iterable[str] = yaml.safe_load(_cfg)["evaluation"]["baselines"]
+
+
+def persistence_baseline(track: Sequence[Sequence[float]], forecast_steps: int) -> np.ndarray:
+    """Simple persistence baseline: repeat last known position and intensity."""
+    track_arr = np.asarray(track)
+    last = track_arr[-1]
+    return np.repeat(last[None, :], forecast_steps, axis=0)
+
+
+def cliper5_baseline(track: Sequence[Sequence[float]], forecast_steps: int) -> np.ndarray:
+    """CLIPER5 baseline using mean motion over last 5 steps."""
+    track_arr = np.asarray(track)
+    if len(track_arr) < 2:
+        return persistence_baseline(track_arr, forecast_steps)
+
+    displacements = np.diff(track_arr[:, :2], axis=0)
+    if len(displacements) >= 5:
+        mean_disp = displacements[-5:].mean(axis=0)
+    else:
+        mean_disp = displacements.mean(axis=0)
+
+    last_pos = track_arr[-1, :2]
+    intensity = track_arr[-1, 2]
+    preds = []
+    for step in range(1, forecast_steps + 1):
+        pos = last_pos + mean_disp * step
+        preds.append(np.array([pos[0], pos[1], intensity]))
+    return np.stack(preds, axis=0)
+
+
+BASELINE_FUNCTIONS = {
+    "persistence": persistence_baseline,
+    "cliper5": cliper5_baseline,
+}
+
+
+def run_baselines(
+    track: Sequence[Sequence[float]],
+    forecast_steps: int,
+    baselines: Iterable[str] | None = None,
+) -> Dict[str, np.ndarray]:
+    """Run selected baseline methods on a storm track."""
+    baselines = baselines or DEFAULT_BASELINES
+    results: Dict[str, np.ndarray] = {}
+    for name in baselines:
+        func = BASELINE_FUNCTIONS.get(name)
+        if func is None:
+            continue
+        results[name] = func(track, forecast_steps)
+    return results

--- a/src/galenet/evaluation/metrics.py
+++ b/src/galenet/evaluation/metrics.py
@@ -1,0 +1,136 @@
+"""Evaluation metrics for GaleNet forecasts."""
+
+from __future__ import annotations
+
+from math import radians, cos
+from pathlib import Path
+from typing import Dict, Iterable, Sequence
+
+import numpy as np
+import yaml
+
+# Load default metrics from configuration without initializing Hydra
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "default_config.yaml"
+with open(_CONFIG_PATH) as _cfg:
+    DEFAULT_METRICS: Iterable[str] = yaml.safe_load(_cfg)["evaluation"]["metrics"]
+
+EARTH_RADIUS_KM = 6371.0
+
+
+def _haversine(
+    lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray
+) -> np.ndarray:
+    """Vectorised haversine distance in kilometers."""
+    lat1, lon1, lat2, lon2 = map(np.radians, [lat1, lon1, lat2, lon2])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = np.sin(dlat / 2) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2) ** 2
+    c = 2 * np.arcsin(np.sqrt(a))
+    return EARTH_RADIUS_KM * c
+
+
+def track_error(pred: Sequence[Sequence[float]], truth: Sequence[Sequence[float]]) -> float:
+    """Mean great-circle distance between predicted and true track in km."""
+    pred_arr = np.asarray(pred)
+    truth_arr = np.asarray(truth)
+    distances = _haversine(
+        pred_arr[:, 0], pred_arr[:, 1], truth_arr[:, 0], truth_arr[:, 1]
+    )
+    return float(np.mean(distances))
+
+
+def _to_xy(lat: float | np.ndarray, lon: float | np.ndarray, ref_lat: float) -> np.ndarray:
+    """Convert lat/lon to local Cartesian x/y in km using equirectangular projection."""
+    lat_rad = np.radians(lat)
+    lon_rad = np.radians(lon)
+    ref_rad = radians(ref_lat)
+    x = EARTH_RADIUS_KM * (lon_rad) * cos(ref_rad)
+    y = EARTH_RADIUS_KM * (lat_rad)
+    return np.stack([x, y], axis=-1)
+
+
+def _along_cross_components(
+    pred: np.ndarray, truth: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute along-track and cross-track error components for each step."""
+    ref_lat = float(np.mean(truth[:, 0]))
+    truth_xy = _to_xy(truth[:, 0], truth[:, 1], ref_lat)
+    pred_xy = _to_xy(pred[:, 0], pred[:, 1], ref_lat)
+
+    along_list = []
+    cross_list = []
+    for i in range(1, len(truth_xy)):
+        dir_vec = truth_xy[i] - truth_xy[i - 1]
+        norm = np.linalg.norm(dir_vec)
+        if norm == 0:
+            continue
+        dir_unit = dir_vec / norm
+        err_vec = pred_xy[i] - truth_xy[i]
+        along_list.append(float(np.dot(err_vec, dir_unit)))
+        cross_list.append(float(dir_unit[0] * err_vec[1] - dir_unit[1] * err_vec[0]))
+
+    return np.asarray(along_list), np.asarray(cross_list)
+
+
+def along_track_error(pred: Sequence[Sequence[float]], truth: Sequence[Sequence[float]]) -> float:
+    """Mean absolute error component along the true track direction in km."""
+    pred_arr = np.asarray(pred)
+    truth_arr = np.asarray(truth)
+    along, _ = _along_cross_components(pred_arr, truth_arr)
+    return float(np.mean(np.abs(along)))
+
+
+def cross_track_error(pred: Sequence[Sequence[float]], truth: Sequence[Sequence[float]]) -> float:
+    """Mean absolute error component perpendicular to true track in km."""
+    pred_arr = np.asarray(pred)
+    truth_arr = np.asarray(truth)
+    _, cross = _along_cross_components(pred_arr, truth_arr)
+    return float(np.mean(np.abs(cross)))
+
+
+def intensity_mae(pred: Sequence[float], truth: Sequence[float]) -> float:
+    """Mean absolute error in storm intensity (e.g., max wind speed)."""
+    pred_arr = np.asarray(pred)
+    truth_arr = np.asarray(truth)
+    return float(np.mean(np.abs(pred_arr - truth_arr)))
+
+
+METRIC_FUNCTIONS = {
+    "track_error": track_error,
+    "along_track_error": along_track_error,
+    "cross_track_error": cross_track_error,
+    "intensity_mae": intensity_mae,
+}
+
+
+def compute_metrics(
+    track_pred: Sequence[Sequence[float]],
+    track_truth: Sequence[Sequence[float]],
+    intensity_pred: Sequence[float],
+    intensity_truth: Sequence[float],
+    metrics: Iterable[str] | None = None,
+) -> Dict[str, float]:
+    """Compute selected metrics for a forecast.
+
+    Args:
+        track_pred: Predicted track coordinates ``(lat, lon)``.
+        track_truth: True track coordinates ``(lat, lon)``.
+        intensity_pred: Predicted intensity values.
+        intensity_truth: True intensity values.
+        metrics: Iterable of metric names. Defaults to
+            ``configs/default_config.yaml::evaluation.metrics``.
+
+    Returns:
+        Dictionary of computed metric values.
+    """
+    metrics = metrics or DEFAULT_METRICS
+    results: Dict[str, float] = {}
+    for name in metrics:
+        func = METRIC_FUNCTIONS.get(name)
+        if func is None:
+            continue
+        if name == "intensity_mae":
+            results[name] = func(intensity_pred, intensity_truth)
+        else:
+            results[name] = func(track_pred, track_truth)
+    return results

--- a/tests/test_evaluation_baselines.py
+++ b/tests/test_evaluation_baselines.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from galenet.evaluation.baselines import run_baselines
+
+
+def test_baseline_predictions():
+    track = np.array([
+        [0.0, 0.0, 40.0],
+        [1.0, 1.0, 42.0],
+        [2.0, 2.0, 44.0],
+        [3.0, 3.0, 46.0],
+        [4.0, 4.0, 48.0],
+        [5.0, 5.0, 50.0],
+    ])
+    forecasts = run_baselines(track, forecast_steps=3, baselines=["persistence", "cliper5"])
+    assert np.allclose(
+        forecasts["persistence"],
+        np.array([[5.0, 5.0, 50.0], [5.0, 5.0, 50.0], [5.0, 5.0, 50.0]]),
+    )
+    assert np.allclose(
+        forecasts["cliper5"],
+        np.array([[6.0, 6.0, 50.0], [7.0, 7.0, 50.0], [8.0, 8.0, 50.0]]),
+    )

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from galenet.evaluation.metrics import (
+    track_error,
+    along_track_error,
+    cross_track_error,
+    intensity_mae,
+    compute_metrics,
+)
+
+
+def _haversine(lat1, lon1, lat2, lon2):
+    r = 6371.0
+    dlat = np.radians(lat2 - lat1)
+    dlon = np.radians(lon2 - lon1)
+    a = np.sin(dlat / 2) ** 2 + np.cos(np.radians(lat1)) * np.cos(
+        np.radians(lat2)
+    ) * np.sin(dlon / 2) ** 2
+    return 2 * r * np.arcsin(np.sqrt(a))
+
+
+def test_metric_computations():
+    truth = np.array([[0.0, 0.0], [0.0, 1.0]])
+    pred = np.array([[0.0, 0.0], [1.0, 1.5]])
+    expected_track = np.mean([
+        0.0,
+        _haversine(1.0, 1.5, 0.0, 1.0),
+    ])
+    assert track_error(pred, truth) == pytest.approx(expected_track, rel=1e-4)
+
+    assert along_track_error(pred, truth) == pytest.approx(55.5, rel=0.02)
+    assert cross_track_error(pred, truth) == pytest.approx(111.0, rel=0.02)
+
+    intens_pred = np.array([50.0, 60.0])
+    intens_true = np.array([52.0, 58.0])
+    assert intensity_mae(intens_pred, intens_true) == pytest.approx(2.0)
+
+    results = compute_metrics(pred, truth, intens_pred, intens_true)
+    assert set(["track_error", "along_track_error", "cross_track_error", "intensity_mae"]) <= set(
+        results.keys()
+    )
+    assert results["intensity_mae"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- implement track, along-track, cross-track and intensity metrics with config-based defaults
- add persistence and CLIPER5 baselines and a runner helper
- cover metrics and baselines with deterministic unit tests

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689816b8d08483268e263c52d4fac59f