### PR TITLE
docs: add data workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ docker run --gpus all -p 8000:8000 galenet:latest
 
 ## 📚 Documentation
 
+- [Data Workflow](docs/data_workflow.md)
 - [Installation Guide](docs/installation.md)
 - [API Reference](docs/api_reference.md)
 - [Model Architecture](docs/architecture.md)

--- a/docs/data_workflow.md
+++ b/docs/data_workflow.md
@@ -1,0 +1,66 @@
+# Data Workflow
+
+This guide outlines required datasets, ERA5 credential setup, and usage of the `HurricaneDataPipeline`.
+
+## Required Datasets
+
+GaleNet expects data in the root directory defined in [`configs/default_config.yaml`](../configs/default_config.yaml):
+
+```
+$HOME/data/galenet/
+├── hurdat2/hurdat2.txt
+├── ibtracs/IBTrACS.ALL.v04r00.nc
+└── era5/
+```
+
+Use the setup script to create directories and download track datasets:
+
+```bash
+python scripts/setup_data.py --download-hurdat2 --download-ibtracs
+```
+
+ERA5 reanalysis data is optional but recommended. With credentials configured (see below), a sample can be fetched using:
+
+```bash
+python scripts/setup_data.py --download-era5
+```
+
+## ERA5 Credential Setup
+
+Downloading ERA5 data requires Copernicus Climate Data Store (CDS) credentials:
+
+1. Register at <https://cds.climate.copernicus.eu/user/register>.
+2. Retrieve your API key from <https://cds.climate.copernicus.eu/api-how-to>.
+3. Provide credentials via either method:
+
+   **Environment variables**
+   ```bash
+   export CDSAPI_URL="https://cds.climate.copernicus.eu/api/v2"
+   export CDSAPI_KEY="<UID>:<API_KEY>"
+   ```
+
+   **or `.cdsapirc` file**
+   ```text
+   url: https://cds.climate.copernicus.eu/api/v2
+   key: <UID>:<API_KEY>
+   ```
+
+## Using `HurricaneDataPipeline`
+
+Once the data directory and ERA5 credentials are in place, initialize the pipeline and load a storm:
+
+```python
+from galenet import HurricaneDataPipeline
+
+pipeline = HurricaneDataPipeline("configs/default_config.yaml")
+storm = pipeline.load_hurricane_for_training(
+    storm_id="AL092023",
+    include_era5=True,
+    patch_size=25.0,
+)
+
+track = storm["track"]          # pandas DataFrame
+era5_patch = storm["era5"]      # xarray Dataset
+```
+
+The call loads the HURDAT2 track and extracts ERA5 patches around the storm path, caching downloads under `$HOME/data/galenet/era5`.


### PR DESCRIPTION
## Summary
- document required datasets and ERA5 credential setup in `docs/data_workflow.md`
- show how to run `HurricaneDataPipeline` with track loading and ERA5 patch extraction
- link the new guide from the README documentation section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68981a4e734083269fbd3553bd7fdf6d