### PR TITLE
Add physics TODOs and extend evaluation test coverage

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -113,9 +113,9 @@ training:
     
   # Physics-informed constraints
   physics:
-    enforce_wind_pressure: true
-    enforce_gradient_wind: true
-    max_intensification_rate: 50  # kt/24hr
+    enforce_wind_pressure: true  # TODO: implement wind-pressure consistency checks
+    enforce_gradient_wind: true  # TODO: enforce gradient wind balance
+    max_intensification_rate: 50  # kt/24hr, TODO: cap intensification in training
     
   # Checkpointing
   checkpoint:

--- a/tests/test_evaluation_baselines.py
+++ b/tests/test_evaluation_baselines.py
@@ -38,3 +38,11 @@ def test_baseline_predictions():
         forecasts["ecmwf"],
         np.array([[5.9, 5.9, 50.0], [6.8, 6.8, 50.0], [7.7, 7.7, 50.0]]),
     )
+
+
+def test_gfs_ecmwf_fallback_to_persistence():
+    track = np.array([[10.0, 20.0, 60.0]])
+    forecasts = run_baselines(track, forecast_steps=2, baselines=["gfs", "ecmwf"])
+    expected = np.array([[10.0, 20.0, 60.0], [10.0, 20.0, 60.0]])
+    assert np.allclose(forecasts["gfs"], expected)
+    assert np.allclose(forecasts["ecmwf"], expected)

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -57,3 +57,13 @@ def test_metric_computations():
     ) <= set(results.keys())
     assert results["intensity_mae"] == pytest.approx(3.3333, rel=1e-4)
     assert results["rapid_intensification_skill"] == pytest.approx(2 / 3, rel=1e-4)
+
+
+def test_rapid_intensification_skill_no_events_or_short_seq():
+    """RI skill should be zero for short sequences or when no events occur."""
+    # Shorter than 24h window
+    assert rapid_intensification_skill([40, 80], [40, 90]) == 0.0
+
+    intens_pred = [40, 42, 43, 44, 45, 46]
+    intens_true = [40, 42, 43, 44, 45, 46]
+    assert rapid_intensification_skill(intens_pred, intens_true) == 0.0


### PR DESCRIPTION
## Summary
- Clarify unimplemented physics constraints in the default configuration
- Add edge-case tests for rapid intensification F1 metric
- Test GFS/ECMWF baselines fallback to persistence when track history is short

## Testing
- `pytest tests/test_evaluation_metrics.py::test_rapid_intensification_skill_no_events_or_short_seq -q`
- `pytest tests/test_evaluation_baselines.py::test_gfs_ecmwf_fallback_to_persistence -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898abee11688326abad6a6b8c25fe16