### PR TITLE
Add minimal GraphCast wrapper and deterministic tests

### DIFF
--- a/src/galenet/inference/pipeline.py
+++ b/src/galenet/inference/pipeline.py
@@ -89,9 +89,9 @@ class GaleNetPipeline:
             checkpoint = getattr(graphcast_cfg, "checkpoint_path", "")
             try:
                 return GraphCastModel(checkpoint)
-            except Exception as exc:  # pragma: no cover - fallback path
-                logger.warning("Failed to load GraphCast model: {}", exc)
-                return _PersistenceModel()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to load GraphCast model: {}", exc)
+                raise RuntimeError("GraphCast model could not be initialized") from exc
 
         if model_name in {"hurricane_ensemble", "ensemble"}:
             return _PersistenceModel()


### PR DESCRIPTION
## Summary
- replace placeholder GraphCast model with lightweight linear layer using official checkpoint format
- make pipeline raise errors if GraphCast initialization fails
- add integration test verifying deterministic forecasts with dummy GraphCast weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898abf37e748326a4e7accbff8573fc