### PR TITLE
Add lightweight GraphCast wrapper and climate inference test

### DIFF
--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -551,7 +551,7 @@ class TestERA5Loader:
 
         calls = []
 
-        def fake_download(start, end, bounds, variables):
+        def fake_download(self, start, end, bounds, variables):
             calls.append((start, end))
             fname = tmp_path / (
                 f"era5_{start.strftime('%Y%m%d')}_{end.strftime('%Y%m%d')}_"


### PR DESCRIPTION
## Summary
- replace `GraphCastModel` with a numpy-based wrapper that loads `.npz` checkpoints and performs linear transforms on climate tensors
- update inference pipeline tests to use the new checkpoint format and add a dedicated climate tensor inference test
- fix ERA5 loader test helper to include `self`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ff87df1608326b99a84011087b9e7