### PR TITLE
Add minimal training utilities and CLI

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Command line interface for training GaleNet models."""
+
+import argparse
+import sys
+from pathlib import Path
+import numpy as np
+
+# Add repository root/src to path
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+
+from galenet.data import HurricaneDataPipeline
+from galenet.models import GraphCastModel
+from galenet.training import HurricaneDataset, Trainer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train a GaleNet model")
+    parser.add_argument("storm_id", help="Storm identifier for training data")
+    parser.add_argument("checkpoint", help="Path to GraphCast checkpoint (.npz)")
+    parser.add_argument("--epochs", type=int, default=1, help="Number of epochs")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    args = parser.parse_args()
+
+    pipeline = HurricaneDataPipeline()
+    dataset = HurricaneDataset(pipeline, [args.storm_id])
+    model = GraphCastModel(args.checkpoint)
+    trainer = Trainer(model, dataset, learning_rate=args.lr)
+
+    for epoch, loss in enumerate(trainer.train(args.epochs), 1):
+        print(f"Epoch {epoch}: loss={loss:.6f}")
+
+    np.savez(args.checkpoint, w=model.w, b=model.b)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/galenet/__init__.py
+++ b/src/galenet/__init__.py
@@ -23,6 +23,7 @@ from .data import (
 
 # Main pipeline
 from .inference.pipeline import GaleNetPipeline
+from .training import HurricaneDataset, Trainer, mse_loss
 
 __all__ = [
     # Version info
@@ -42,6 +43,11 @@ __all__ = [
 
     # Main pipeline
     "GaleNetPipeline",
+
+    # Training utilities
+    "HurricaneDataset",
+    "Trainer",
+    "mse_loss",
 ]
 
 # Package metadata

--- a/src/galenet/training/__init__.py
+++ b/src/galenet/training/__init__.py
@@ -1,0 +1,7 @@
+"""Training utilities for GaleNet models."""
+
+from .datasets import HurricaneDataset
+from .losses import mse_loss
+from .trainer import Trainer
+
+__all__ = ["HurricaneDataset", "mse_loss", "Trainer"]

--- a/src/galenet/training/datasets.py
+++ b/src/galenet/training/datasets.py
@@ -1,0 +1,44 @@
+"""Dataset helpers for training models."""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator, Sequence, Tuple, List
+
+import numpy as np
+
+from ..data import HurricaneDataPipeline
+
+
+class HurricaneDataset(Iterable[Tuple[np.ndarray, np.ndarray]]):
+    """Iterable of input/target pairs derived from hurricane tracks.
+
+    The dataset iterates over consecutive observations from the storms
+    provided at construction time. Each sample contains the state at time
+    ``t`` and the state at ``t+1`` as ``numpy.ndarray`` vectors with the
+    ordering ``(latitude, longitude, max_wind, min_pressure)``.
+    """
+
+    def __init__(self, pipeline: HurricaneDataPipeline, storms: Sequence[str]):
+        self.pipeline = pipeline
+        self.storms = list(storms)
+        self.samples: List[Tuple[np.ndarray, np.ndarray]] = []
+        self._prepare()
+
+    # ------------------------------------------------------------------
+    def _prepare(self) -> None:
+        for storm_id in self.storms:
+            data = self.pipeline.load_hurricane_for_training(
+                storm_id, include_era5=False
+            )
+            track = data["track"].sort_values("timestamp").reset_index(drop=True)
+            cols = ["latitude", "longitude", "max_wind", "min_pressure"]
+            arr = track[cols].to_numpy(dtype=np.float32)
+            for i in range(len(arr) - 1):
+                self.samples.append((arr[i], arr[i + 1]))
+
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.samples)
+
+    def __iter__(self) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
+        return iter(self.samples)

--- a/src/galenet/training/losses.py
+++ b/src/galenet/training/losses.py
@@ -1,0 +1,21 @@
+"""Loss functions for model training."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def mse_loss(pred: np.ndarray, target: np.ndarray) -> tuple[float, np.ndarray]:
+    """Return mean squared error and gradient w.r.t ``pred``.
+
+    Parameters
+    ----------
+    pred, target:
+        Vectors of identical shape representing model predictions and
+        ground truth values.
+    """
+
+    diff = pred - target
+    loss = float(np.mean(diff ** 2))
+    grad = (2.0 / diff.size) * diff
+    return loss, grad

--- a/src/galenet/training/trainer.py
+++ b/src/galenet/training/trainer.py
@@ -1,0 +1,50 @@
+"""Minimal training loop for simple linear models."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Iterator, Tuple
+
+import numpy as np
+
+from .losses import mse_loss
+
+ArrayPair = Tuple[np.ndarray, np.ndarray]
+
+
+class Trainer:
+    """Tiny trainer operating on numpy arrays.
+
+    The trainer assumes the ``model`` object exposes ``w`` and ``b`` attributes
+    (``numpy.ndarray``) and provides an ``infer`` method returning predictions for
+    a single input vector. This matches the :class:`~galenet.models.graphcast.GraphCastModel`
+    API and is also compatible with similar Pangu-style models.
+    """
+
+    def __init__(
+        self,
+        model: any,
+        dataset: Iterable[ArrayPair],
+        loss_fn: Callable[[np.ndarray, np.ndarray], Tuple[float, np.ndarray]] = mse_loss,
+        learning_rate: float = 1e-3,
+    ) -> None:
+        self.model = model
+        self.dataset = dataset
+        self.loss_fn = loss_fn
+        self.learning_rate = float(learning_rate)
+
+    # ------------------------------------------------------------------
+    def train(self, epochs: int = 1) -> Iterator[float]:
+        """Yield average loss for each epoch."""
+
+        for _ in range(epochs):
+            total = 0.0
+            count = 0
+            for x, y in self.dataset:
+                pred = self.model.infer(x)
+                loss, grad = self.loss_fn(pred, y)
+                # Gradient descent update for linear layer
+                self.model.w -= self.learning_rate * np.outer(x, grad)
+                self.model.b -= self.learning_rate * grad
+                total += loss
+                count += 1
+            yield total / max(count, 1)


### PR DESCRIPTION
## Summary
- add `training` package with hurricane dataset generator, MSE loss, and simple trainer
- expose training utilities via package `__init__`
- provide `scripts/train_model.py` CLI for running training jobs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ffb33f5508326a6dccc644760e76a