### PR TITLE
Add multi-storm evaluation utilities and CLI

### DIFF
--- a/scripts/evaluate_baselines.py
+++ b/scripts/evaluate_baselines.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""CLI for evaluating baseline forecasts across storms.
+
+This script expects a JSON file containing a list of storms. Each storm is a
+mapping with a ``track`` key holding a list of ``[lat, lon, intensity]``
+triplets. The first ``--history`` steps of each track are used as input for the
+baselines and the next ``--forecast`` steps are compared against the baseline
+forecasts using the evaluation metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+from galenet.evaluation.baselines import evaluate_baselines
+
+
+def _load_storms(path: Path) -> List[np.ndarray]:
+    with open(path) as f:
+        data = json.load(f)
+    return [np.asarray(storm["track"], dtype=float) for storm in data]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate baseline forecasts")
+    parser.add_argument("data", type=Path, help="Path to JSON file containing storm tracks")
+    parser.add_argument("--history", type=int, default=3, help="Number of history steps")
+    parser.add_argument("--forecast", type=int, default=2, help="Number of forecast steps")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    storms = _load_storms(args.data)
+    results = evaluate_baselines(storms, args.history, args.forecast)
+    for baseline, metrics in results.items():
+        logging.info("%s:", baseline)
+        for name, value in metrics.items():
+            logging.info("  %s: %.3f", name, value)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/galenet/evaluation/__init__.py
+++ b/src/galenet/evaluation/__init__.py
@@ -6,9 +6,11 @@ from .metrics import (
     cross_track_error,
     intensity_mae,
     compute_metrics,
+    compute_metrics_multi,
 )
 from .baselines import (
     run_baselines,
+    evaluate_baselines,
     persistence_baseline,
     cliper5_baseline,
 )
@@ -19,7 +21,9 @@ __all__ = [
     "cross_track_error",
     "intensity_mae",
     "compute_metrics",
+    "compute_metrics_multi",
     "run_baselines",
+    "evaluate_baselines",
     "persistence_baseline",
     "cliper5_baseline",
 ]

--- a/tests/test_evaluation_baselines.py
+++ b/tests/test_evaluation_baselines.py
@@ -2,10 +2,12 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 
-from galenet.evaluation.baselines import run_baselines
+from galenet.evaluation.baselines import run_baselines, evaluate_baselines
+from galenet.evaluation.metrics import compute_metrics
 
 
 def test_baseline_predictions():
@@ -46,3 +48,59 @@ def test_gfs_ecmwf_fallback_to_persistence():
     expected = np.array([[10.0, 20.0, 60.0], [10.0, 20.0, 60.0]])
     assert np.allclose(forecasts["gfs"], expected)
     assert np.allclose(forecasts["ecmwf"], expected)
+
+
+def test_evaluate_baselines_multi_storm():
+    storms = [
+        np.array(
+            [
+                [0.0, 0.0, 40.0],
+                [1.0, 1.0, 41.0],
+                [2.0, 2.0, 42.0],
+                [3.0, 3.0, 43.0],
+            ]
+        ),
+        np.array(
+            [
+                [10.0, 10.0, 30.0],
+                [11.0, 10.0, 32.0],
+                [12.0, 10.0, 34.0],
+                [13.0, 10.0, 36.0],
+            ]
+        ),
+    ]
+
+    summary = evaluate_baselines(
+        storms,
+        history_steps=2,
+        forecast_steps=2,
+        baselines=["persistence"],
+        metrics=["track_error", "intensity_mae"],
+    )
+
+    # compute expected values manually
+    f1 = run_baselines(storms[0][:2], 2, baselines=["persistence"])["persistence"]
+    m1 = compute_metrics(
+        f1[:, :2],
+        storms[0][2:, :2],
+        f1[:, 2],
+        storms[0][2:, 2],
+        metrics=["track_error", "intensity_mae"],
+    )
+
+    f2 = run_baselines(storms[1][:2], 2, baselines=["persistence"])["persistence"]
+    m2 = compute_metrics(
+        f2[:, :2],
+        storms[1][2:, :2],
+        f2[:, 2],
+        storms[1][2:, 2],
+        metrics=["track_error", "intensity_mae"],
+    )
+
+    expected_track = (m1["track_error"] + m2["track_error"]) / 2
+    expected_intensity = (m1["intensity_mae"] + m2["intensity_mae"]) / 2
+
+    assert summary["persistence"]["track_error"] == pytest.approx(expected_track, rel=1e-4)
+    assert summary["persistence"]["intensity_mae"] == pytest.approx(
+        expected_intensity, rel=1e-4
+    )


### PR DESCRIPTION
## Summary
- Support summarising metrics across storms with `compute_metrics_multi`
- Add `evaluate_baselines` to aggregate baseline performance over many storms
- Provide `scripts/evaluate_baselines.py` CLI for running metrics on forecast files
- Add regression test for multi-storm baseline evaluation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ffca537748326859cce9d6c207ca3