### PR TITLE
Add data pipeline docs and tutorial notebooks

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,6 +9,7 @@ This document provides a quick snapshot of GaleNet's progress and what's next.
 - Repository tooling for testing, linting, and packaging configured.
 - Expanded preprocessing and feature engineering for ERA5 dataset.
 - Evaluation framework and benchmarking suite established.
+- Published data pipeline documentation and tutorial notebooks.
 
 ## Remaining Milestones
 - Develop full training loop for GraphCast/Pangu-based models.
@@ -17,14 +18,14 @@ This document provides a quick snapshot of GaleNet's progress and what's next.
 - **Data Foundation**
    - Finalize dataset loaders for ERA5, HURDAT2, and IBTrACS *(High priority, target: 2025-09)*
    - Validate preprocessing pipeline and feature engineering steps *(High priority, target: 2025-09)*
-   - Document end-to-end data pipeline and schema *(Medium priority, target: 2025-10)*
+   - Expand end-to-end data pipeline documentation and schema coverage *(Medium priority, target: 2025-10)*
 
 ## Phase Goals
 1. **Data Foundation**
    - Finalize dataset loaders for ERA5, HURDAT2, and IBTrACS *(High priority, target: 2025-09)*
    - Validate preprocessing pipeline and feature engineering steps *(High priority, target: 2025-09)*
-   - Document end-to-end data pipeline and schema *(Medium priority, target: 2025-10)*
+   - Expand end-to-end data pipeline documentation and schema coverage *(Medium priority, target: 2025-10)*
 2. **Model Development** – integrate forecast models and train baseline hurricane predictors.
 3. **Evaluation & Deployment** – benchmark models, refine APIs, and prepare for public release.
 
-_Last updated: 2025-08-12_
+_Last updated: 2025-08-13_

--- a/README.md
+++ b/README.md
@@ -160,11 +160,13 @@ docker run --gpus all -p 8000:8000 galenet:latest
 
 ## 📚 Documentation
 
+- [Data Pipeline](docs/data_pipeline.md)
 - [Data Workflow](docs/data_workflow.md)
 - [Installation Guide](docs/installation.md)
 - [API Reference](docs/api_reference.md)
 - [Model Architecture](docs/architecture.md)
 - [Training Guide](docs/training.md)
+- [Tutorial Notebooks](notebooks/)
 
 ## 🔬 Research
 

--- a/docs/data_pipeline.md
+++ b/docs/data_pipeline.md
@@ -1,0 +1,52 @@
+# Data Pipeline
+
+This document describes the data pipeline used by GaleNet, including dataset schemas, preprocessing stages, and ERA5 patch extraction.
+
+## Dataset Schemas
+
+### HURDAT2 and IBTrACS Track Data
+
+Storm track records are normalised to a common schema with the following core fields:
+
+| Column | Description |
+|--------|-------------|
+| `storm_id` | Basin identifier and year (e.g., `AL092019`) |
+| `name` | Storm name in uppercase |
+| `timestamp` | Observation time in UTC |
+| `latitude` | Degrees north (negative south) |
+| `longitude` | Degrees east (negative west) |
+| `max_wind` | Maximum sustained wind in knots |
+| `min_pressure` | Minimum central pressure in hPa |
+| `34kt_ne`, `34kt_se`, `34kt_sw`, `34kt_nw` | Optional wind radii |
+
+IBTrACS provides the same physical quantities but may contain additional metadata. All fields are cast to numeric types and timestamps are parsed into ``pandas`` ``datetime`` objects.
+
+### ERA5 Reanalysis
+
+ERA5 fields are stored as an ``xarray.Dataset`` with dimensions ``time`` x ``latitude`` x ``longitude``. Typical variables include:
+
+- Surface: `u10`, `v10`, `msl`, `t2m`, `sst`
+- Pressure levels: `u{level}` and `v{level}` (e.g., `u850`)
+
+Each file encodes CF-compliant attributes allowing direct use with `xarray` or `pint` for unit handling.
+
+## Preprocessing Workflow
+
+1. **Track Loading** – HURDAT2/IBTrACS records are read, sorted by time, and converted to the unified schema above.
+2. **Normalization** – Latitudes, longitudes, and intensity values are scaled; categorical flags are one‑hot encoded.
+3. **Feature Engineering** – Additional predictors such as forward speed, bearing, and environmental shear are derived.
+4. **Quality Checks** – ``HurricaneDataValidator`` enforces physical limits (e.g., pressure ranges) and timestamps spacing.
+5. **Dataset Assembly** – When ERA5 data are requested, atmospheric patches are merged with the track for downstream models.
+
+## ERA5 Patch Extraction
+
+ERA5 patches provide the model with environmental context around the storm path:
+
+1. **Bounds** – For a given track, spatial bounds are computed from the min/max latitude and longitude with a configurable ``patch_size`` (default ``25°``) margin.
+2. **Time Window** – Data can include a lead and lag window (``lead_time_hours`` and ``lag_time_hours``) around the observation period.
+3. **Download** – ``ERA5Loader.download_data`` requests the required variables and time range from the Copernicus Climate Data Store, caching results on disk.
+4. **Extraction** – ``ERA5Loader.extract_hurricane_patches`` or ``HurricaneDataPipeline`` slices the downloaded dataset into patches following the storm track. Dateline crossings are handled by stitching split patches.
+5. **Output** – The final dataset is an ``xarray.Dataset`` aligned with track timestamps and ready for model ingestion.
+
+This process enables consistent preprocessing across training and inference, ensuring storms share a common representation and environmental context.
+

--- a/notebooks/generate_forecast.ipynb
+++ b/notebooks/generate_forecast.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c221bc60",
+   "metadata": {},
+   "source": [
+    "## Generate a Forecast\n",
+    "This tutorial runs the `GaleNetPipeline` to produce a short forecast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18c3cfd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from galenet import GaleNetPipeline\n",
+    "\n",
+    "pipeline = GaleNetPipeline(\"configs/default_config.yaml\")\n",
+    "result = pipeline.forecast_storm(\"AL092019\", forecast_hours=24)\n",
+    "result.track.head()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/load_storm.ipynb
+++ b/notebooks/load_storm.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9872fda2",
+   "metadata": {},
+   "source": [
+    "## Load a Storm\n",
+    "This tutorial demonstrates loading a hurricane track using `HURDAT2Loader`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3880eacd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from galenet.data.loaders import HURDAT2Loader\n",
+    "\n",
+    "loader = HURDAT2Loader()\n",
+    "track = loader.get_storm(\"AL092019\")\n",
+    "track.head()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- document datasets, preprocessing steps, and ERA5 patch extraction
- add notebooks for loading storms and generating forecasts
- reference new docs from README and project status

## Testing
- `make lint` *(fails: F401, E501, E402)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ffe83e9688326ac3b556a55f1b117