### PR TITLE
Integrate PyTorch training utilities and tests

### DIFF
--- a/src/galenet/training/__init__.py
+++ b/src/galenet/training/__init__.py
@@ -1,7 +1,7 @@
 """Training utilities for GaleNet models."""
 
-from .datasets import HurricaneDataset
+from .datasets import HurricaneDataset, create_dataloader
 from .losses import mse_loss
 from .trainer import Trainer
 
-__all__ = ["HurricaneDataset", "mse_loss", "Trainer"]
+__all__ = ["HurricaneDataset", "create_dataloader", "mse_loss", "Trainer"]

--- a/src/galenet/training/datasets.py
+++ b/src/galenet/training/datasets.py
@@ -1,44 +1,99 @@
-"""Dataset helpers for training models."""
+"""PyTorch datasets for GaleNet training."""
 
 from __future__ import annotations
 
-from typing import Iterable, Iterator, Sequence, Tuple, List
+from typing import Iterable, Iterator, List, Sequence, Tuple
 
 import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
 
 from ..data import HurricaneDataPipeline
 
 
-class HurricaneDataset(Iterable[Tuple[np.ndarray, np.ndarray]]):
-    """Iterable of input/target pairs derived from hurricane tracks.
+TrackPair = Tuple[torch.Tensor, torch.Tensor]
+TrackTriplet = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 
-    The dataset iterates over consecutive observations from the storms
-    provided at construction time. Each sample contains the state at time
-    ``t`` and the state at ``t+1`` as ``numpy.ndarray`` vectors with the
-    ordering ``(latitude, longitude, max_wind, min_pressure)``.
+
+class HurricaneDataset(Dataset[Tuple[torch.Tensor, ...]]):
+    """Dataset yielding track sequence windows and optional ERA5 patches.
+
+    Parameters
+    ----------
+    pipeline:
+        ``HurricaneDataPipeline`` instance used to load storm data.
+    storms:
+        Iterable of storm identifiers.
+    window:
+        Number of sequential observations to include in the input window.
+    include_era5:
+        Whether to include ERA5 patches in the samples.  When ``True`` and
+        corresponding data are available, each sample becomes a triplet of
+        ``(sequence, target, era5_patch)``.  Otherwise it yields ``(sequence,
+        target)`` pairs.
     """
 
-    def __init__(self, pipeline: HurricaneDataPipeline, storms: Sequence[str]):
+    def __init__(
+        self,
+        pipeline: HurricaneDataPipeline,
+        storms: Sequence[str],
+        window: int = 1,
+        include_era5: bool = False,
+    ) -> None:
         self.pipeline = pipeline
         self.storms = list(storms)
-        self.samples: List[Tuple[np.ndarray, np.ndarray]] = []
+        self.window = int(window)
+        self.include_era5 = bool(include_era5)
+
+        self.samples: List[Tuple[torch.Tensor, ...]] = []
         self._prepare()
 
     # ------------------------------------------------------------------
     def _prepare(self) -> None:
+        cols = ["latitude", "longitude", "max_wind", "min_pressure"]
         for storm_id in self.storms:
             data = self.pipeline.load_hurricane_for_training(
-                storm_id, include_era5=False
+                storm_id, include_era5=self.include_era5
             )
             track = data["track"].sort_values("timestamp").reset_index(drop=True)
-            cols = ["latitude", "longitude", "max_wind", "min_pressure"]
             arr = track[cols].to_numpy(dtype=np.float32)
-            for i in range(len(arr) - 1):
-                self.samples.append((arr[i], arr[i + 1]))
+
+            era5 = data.get("era5") if self.include_era5 else None
+            if era5 is not None:
+                try:
+                    era5_arr = np.asarray(era5)
+                except Exception:  # pragma: no cover - very defensive
+                    era5_arr = np.asarray(getattr(era5, "to_array")())
+            else:
+                era5_arr = None
+
+            for i in range(len(arr) - self.window):
+                seq = torch.from_numpy(arr[i : i + self.window])
+                target = torch.from_numpy(arr[i + self.window])
+                if era5_arr is not None:
+                    patch = torch.from_numpy(era5_arr[i + self.window])
+                    self.samples.append((seq, target, patch))
+                else:
+                    self.samples.append((seq, target))
 
     # ------------------------------------------------------------------
     def __len__(self) -> int:  # pragma: no cover - trivial
         return len(self.samples)
 
-    def __iter__(self) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
-        return iter(self.samples)
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, ...]:
+        return self.samples[idx]
+
+
+# ---------------------------------------------------------------------------
+def create_dataloader(
+    dataset: HurricaneDataset,
+    batch_size: int = 32,
+    shuffle: bool = True,
+    **kwargs: object,
+) -> DataLoader:
+    """Create a :class:`~torch.utils.data.DataLoader` for ``dataset``."""
+
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, **kwargs)
+
+
+__all__ = ["HurricaneDataset", "create_dataloader"]

--- a/src/galenet/training/trainer.py
+++ b/src/galenet/training/trainer.py
@@ -1,50 +1,72 @@
-"""Minimal training loop for simple linear models."""
+"""PyTorch-based training utilities."""
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, Iterator, Tuple
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
 
-import numpy as np
-
-from .losses import mse_loss
-
-ArrayPair = Tuple[np.ndarray, np.ndarray]
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader
 
 
 class Trainer:
-    """Tiny trainer operating on numpy arrays.
-
-    The trainer assumes the ``model`` object exposes ``w`` and ``b`` attributes
-    (``numpy.ndarray``) and provides an ``infer`` method returning predictions for
-    a single input vector. This matches the :class:`~galenet.models.graphcast.GraphCastModel`
-    API and is also compatible with similar Pangu-style models.
-    """
+    """Simple trainer handling optimization and checkpointing."""
 
     def __init__(
         self,
-        model: any,
-        dataset: Iterable[ArrayPair],
-        loss_fn: Callable[[np.ndarray, np.ndarray], Tuple[float, np.ndarray]] = mse_loss,
-        learning_rate: float = 1e-3,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        loss_fn: nn.Module | None = None,
+        device: torch.device | str = "cpu",
     ) -> None:
-        self.model = model
-        self.dataset = dataset
-        self.loss_fn = loss_fn
-        self.learning_rate = float(learning_rate)
+        self.model = model.to(device)
+        self.optimizer = optimizer
+        self.loss_fn = loss_fn or nn.MSELoss()
+        self.device = torch.device(device)
 
     # ------------------------------------------------------------------
-    def train(self, epochs: int = 1) -> Iterator[float]:
+    def train(self, dataloader: DataLoader, epochs: int = 1) -> Iterator[float]:
         """Yield average loss for each epoch."""
 
         for _ in range(epochs):
+            self.model.train()
             total = 0.0
             count = 0
-            for x, y in self.dataset:
-                pred = self.model.infer(x)
-                loss, grad = self.loss_fn(pred, y)
-                # Gradient descent update for linear layer
-                self.model.w -= self.learning_rate * np.outer(x, grad)
-                self.model.b -= self.learning_rate * grad
-                total += loss
+            for batch in dataloader:
+                if isinstance(batch, (list, tuple)):
+                    inputs, targets = batch[0], batch[1]
+                else:  # pragma: no cover - defensive
+                    inputs, targets = batch
+                inputs = inputs.to(self.device, dtype=torch.float32)
+                targets = targets.to(self.device, dtype=torch.float32)
+
+                self.optimizer.zero_grad()
+                preds = self.model(inputs)
+                loss = self.loss_fn(preds, targets)
+                loss.backward()
+                self.optimizer.step()
+
+                total += float(loss.item())
                 count += 1
             yield total / max(count, 1)
+
+    # ------------------------------------------------------------------
+    def save_checkpoint(self, path: str | Path) -> None:
+        """Persist model and optimizer state to ``path``."""
+
+        ckpt = {
+            "model": self.model.state_dict(),
+            "optimizer": self.optimizer.state_dict(),
+        }
+        torch.save(ckpt, Path(path))
+
+    def load_checkpoint(self, path: str | Path) -> None:
+        """Load model and optimizer state from ``path``."""
+
+        ckpt = torch.load(Path(path), map_location=self.device)
+        self.model.load_state_dict(ckpt["model"])
+        self.optimizer.load_state_dict(ckpt["optimizer"])
+
+
+__all__ = ["Trainer"]

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import numpy as np
+import torch
+
+from galenet.training import HurricaneDataset, Trainer, create_dataloader
+
+
+class DummyPipeline:
+    """Minimal stand-in for :class:`HurricaneDataPipeline`."""
+
+    def load_hurricane_for_training(self, storm_id, include_era5=False, patch_size: float = 25.0):
+        times = pd.date_range("2020-01-01", periods=5, freq="H")
+        values = np.arange(1, 6, dtype=float)
+        df = pd.DataFrame(
+            {
+                "timestamp": times,
+                "latitude": values,
+                "longitude": values,
+                "max_wind": values,
+                "min_pressure": values,
+            }
+        )
+        return {"track": df}
+
+
+def test_dataset_iteration() -> None:
+    pipeline = DummyPipeline()
+    dataset = HurricaneDataset(pipeline, ["TEST"], window=2, include_era5=False)
+
+    assert len(dataset) == 3
+    seq, target = dataset[0]
+    assert seq.shape == (2, 4)
+    assert target.shape == (4,)
+
+    loader = create_dataloader(dataset, batch_size=2, shuffle=False)
+    batch_seq, batch_target = next(iter(loader))
+    assert batch_seq.shape == (2, 2, 4)
+    assert batch_target.shape == (2, 4)
+
+
+def test_trainer_single_step_reduces_loss() -> None:
+    pipeline = DummyPipeline()
+    dataset = HurricaneDataset(pipeline, ["TEST"], window=1, include_era5=False)
+    loader = create_dataloader(dataset, batch_size=1, shuffle=False)
+
+    model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 4, bias=False))
+    torch.nn.init.zeros_(model[1].weight)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = Trainer(model, optimizer)
+
+    batch_inputs, batch_targets = next(iter(loader))
+    with torch.no_grad():
+        initial = torch.nn.functional.mse_loss(model(batch_inputs), batch_targets).item()
+
+    list(trainer.train(loader, epochs=1))
+
+    with torch.no_grad():
+        final = torch.nn.functional.mse_loss(model(batch_inputs), batch_targets).item()
+
+    assert final < initial


### PR DESCRIPTION
## Summary
- Add PyTorch `HurricaneDataset` and `create_dataloader` for sequence windows and optional ERA5 patches
- Introduce torch-based `Trainer` with optimizer loop and checkpoint support
- Refresh training script to use Hydra configs, checkpoints, and metric logging
- Test dataset iteration and that a training step decreases loss

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a003bdb8cc8326ac9d5b3fd9c95b84