### PR TITLE
feat: evaluate baselines alongside model forecasts

### DIFF
--- a/scripts/evaluate_baselines.py
+++ b/scripts/evaluate_baselines.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""CLI for evaluating baseline forecasts across storms.
+"""CLI for evaluating baseline and model forecasts across storms.
 
 This script expects a JSON file containing a list of storms. Each storm is a
 mapping with a ``track`` key holding a list of ``[lat, lon, intensity]``
 triplets. The first ``--history`` steps of each track are used as input for the
-baselines and the next ``--forecast`` steps are compared against the baseline
-forecasts using the evaluation metrics.
+baselines and the next ``--forecast`` steps are compared against the forecasts
+using the evaluation metrics.  When ``--model-config`` is provided, a
+``GaleNetPipeline`` instance is created and its model is run alongside the
+baselines.
 """
 
 from __future__ import annotations
@@ -16,9 +18,12 @@ import logging
 from pathlib import Path
 from typing import List
 
+import pandas as pd
+
 import numpy as np
 
 from galenet.evaluation.baselines import evaluate_baselines
+from galenet import GaleNetPipeline
 
 
 def _load_storms(path: Path) -> List[np.ndarray]:
@@ -28,15 +33,47 @@ def _load_storms(path: Path) -> List[np.ndarray]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Evaluate baseline forecasts")
+    parser = argparse.ArgumentParser(
+        description="Evaluate baseline and model forecasts"
+    )
     parser.add_argument("data", type=Path, help="Path to JSON file containing storm tracks")
     parser.add_argument("--history", type=int, default=3, help="Number of history steps")
     parser.add_argument("--forecast", type=int, default=2, help="Number of forecast steps")
+    parser.add_argument(
+        "--model-config",
+        type=Path,
+        default=None,
+        help="Optional path to config for running GaleNetPipeline forecasts",
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default="model",
+        help="Name to use for reporting model metrics",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
     storms = _load_storms(args.data)
-    results = evaluate_baselines(storms, args.history, args.forecast)
+    model_forecasts = None
+    if args.model_config is not None:
+        pipeline = GaleNetPipeline(str(args.model_config))
+        model_forecasts = []
+        for storm in storms:
+            history = storm[: args.history]
+            df = pd.DataFrame(history, columns=["latitude", "longitude", "max_wind"])
+            preds = pipeline.model.predict(df, args.forecast, 1)
+            model_forecasts.append(
+                preds[["latitude", "longitude", "max_wind"]].to_numpy()
+            )
+
+    results = evaluate_baselines(
+        storms,
+        args.history,
+        args.forecast,
+        model_forecasts=model_forecasts,
+        model_name=args.model_name,
+    )
     for baseline, metrics in results.items():
         logging.info("%s:", baseline)
         for name, value in metrics.items():


### PR DESCRIPTION
## Summary
- allow `evaluate_baselines` to score optional model forecasts together with baseline methods
- expand `scripts/evaluate_baselines.py` to run `GaleNetPipeline` forecasts in addition to baselines
- add regression test ensuring metrics aggregate for both model and baselines

## Testing
- `pytest tests/test_evaluation_baselines.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a0067ec71083268f19f85132ef2e8e