### PR TITLE
feat: add lightweight graphcast wrapper and tests

### DIFF
--- a/src/galenet/__init__.py
+++ b/src/galenet/__init__.py
@@ -23,7 +23,13 @@ from .data import (
 
 # Main pipeline
 from .inference.pipeline import GaleNetPipeline
-from .training import HurricaneDataset, Trainer, mse_loss
+# Training utilities require optional dependencies (e.g., PyTorch).  Import them
+# lazily so that inference-only environments can function without the heavy ML
+# stack installed.
+try:  # pragma: no cover - import guard
+    from .training import HurricaneDataset, Trainer, mse_loss
+except Exception:  # pragma: no cover - optional
+    HurricaneDataset = Trainer = mse_loss = None  # type: ignore
 
 __all__ = [
     # Version info

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -155,12 +155,16 @@ def test_lead_times_and_validation_warning(monkeypatch, sample_track):
 def test_graphcast_realistic_forecast(monkeypatch, tmp_path, sample_track):
     """Pipeline produces forecasts transformed by GraphCast weights."""
 
-    # Create a checkpoint shifting each step by a fixed amount
+    # Create a checkpoint shifting each step by a fixed amount.  Use the nested
+    # ``{"params": {"w": ..., "b": ...}}`` structure exported by the official
+    # GraphCast codebase to ensure our loader handles DeepMind checkpoints.
     ckpt_path = tmp_path / "params.npz"
     np.savez(
         ckpt_path,
-        w=np.eye(4, dtype=np.float32),
-        b=np.array([1.0, -1.0, 2.0, -2.0], dtype=np.float32),
+        params={
+            "w": np.eye(4, dtype=np.float32),
+            "b": np.array([1.0, -1.0, 2.0, -2.0], dtype=np.float32),
+        },
     )
 
     config = OmegaConf.load(CONFIG_PATH)


### PR DESCRIPTION
## Summary
- wrap GraphCast with a lightweight linear layer that optionally uses PyTorch and can load DeepMind checkpoints
- make package initialization resilient when training deps like torch are missing
- add regression tests for GraphCast forecasts and array inference

## Testing
- `pytest tests/test_inference_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0106a55cc8326aae137a2bfe43a3c