### PR TITLE
feat: extend training pipeline with streaming datasets and checkpointing

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -98,6 +98,11 @@ training:
   weight_decay: 1e-4
   gradient_clip: 1.0
   gradient_accumulation_steps: 8
+  storms: ["AL012011"]
+  sequence_window: 1
+  forecast_window: 1
+  include_era5: false
+  shuffle: true
   
   # Scheduler
   scheduler:

--- a/src/galenet/training/datasets.py
+++ b/src/galenet/training/datasets.py
@@ -6,7 +6,7 @@ from typing import Iterable, Iterator, List, Sequence, Tuple
 
 import numpy as np
 import torch
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader, IterableDataset
 
 from ..data import HurricaneDataPipeline
 
@@ -15,41 +15,42 @@ TrackPair = Tuple[torch.Tensor, torch.Tensor]
 TrackTriplet = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 
 
-class HurricaneDataset(Dataset[Tuple[torch.Tensor, ...]]):
-    """Dataset yielding track sequence windows and optional ERA5 patches.
+class HurricaneDataset(IterableDataset[Tuple[torch.Tensor, ...]]):
+    """Stream track windows across multiple storms.
 
-    Parameters
-    ----------
-    pipeline:
-        ``HurricaneDataPipeline`` instance used to load storm data.
-    storms:
-        Iterable of storm identifiers.
-    window:
-        Number of sequential observations to include in the input window.
-    include_era5:
-        Whether to include ERA5 patches in the samples.  When ``True`` and
-        corresponding data are available, each sample becomes a triplet of
-        ``(sequence, target, era5_patch)``.  Otherwise it yields ``(sequence,
-        target)`` pairs.
+    The dataset yields tuples of ``(sequence, target)`` or
+    ``(sequence, target, era5_patch)`` depending on the ``include_era5``
+    flag. ``sequence`` spans ``sequence_window`` observations while ``target``
+    contains ``forecast_window`` future observations.
     """
 
     def __init__(
         self,
         pipeline: HurricaneDataPipeline,
         storms: Sequence[str],
-        window: int = 1,
+        sequence_window: int = 1,
+        forecast_window: int = 1,
         include_era5: bool = False,
     ) -> None:
         self.pipeline = pipeline
         self.storms = list(storms)
-        self.window = int(window)
+        self.sequence_window = int(sequence_window)
+        self.forecast_window = int(forecast_window)
         self.include_era5 = bool(include_era5)
 
-        self.samples: List[Tuple[torch.Tensor, ...]] = []
-        self._prepare()
+        # Pre-compute the total length for __len__ without storing samples.
+        self._length = 0
+        cols = ["latitude", "longitude", "max_wind", "min_pressure"]
+        for storm_id in self.storms:
+            data = self.pipeline.load_hurricane_for_training(storm_id, include_era5=False)
+            track = data["track"].sort_values("timestamp").reset_index(drop=True)
+            arr = track[cols].to_numpy(dtype=np.float32)
+            self._length += max(
+                len(arr) - self.sequence_window - self.forecast_window + 1, 0
+            )
 
     # ------------------------------------------------------------------
-    def _prepare(self) -> None:
+    def __iter__(self) -> Iterator[Tuple[torch.Tensor, ...]]:
         cols = ["latitude", "longitude", "max_wind", "min_pressure"]
         for storm_id in self.storms:
             data = self.pipeline.load_hurricane_for_training(
@@ -67,21 +68,35 @@ class HurricaneDataset(Dataset[Tuple[torch.Tensor, ...]]):
             else:
                 era5_arr = None
 
-            for i in range(len(arr) - self.window):
-                seq = torch.from_numpy(arr[i : i + self.window])
-                target = torch.from_numpy(arr[i + self.window])
+            limit = len(arr) - self.sequence_window - self.forecast_window + 1
+            for i in range(max(limit, 0)):
+                seq = torch.from_numpy(
+                    arr[i : i + self.sequence_window]
+                )
+                target = torch.from_numpy(
+                    arr[
+                        i
+                        + self.sequence_window : i
+                        + self.sequence_window
+                        + self.forecast_window
+                    ]
+                )
                 if era5_arr is not None:
-                    patch = torch.from_numpy(era5_arr[i + self.window])
-                    self.samples.append((seq, target, patch))
+                    patch = torch.from_numpy(
+                        era5_arr[
+                            i
+                            + self.sequence_window : i
+                            + self.sequence_window
+                            + self.forecast_window
+                        ]
+                    )
+                    yield (seq, target, patch)
                 else:
-                    self.samples.append((seq, target))
+                    yield (seq, target)
 
     # ------------------------------------------------------------------
     def __len__(self) -> int:  # pragma: no cover - trivial
-        return len(self.samples)
-
-    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, ...]:
-        return self.samples[idx]
+        return self._length
 
 
 # ---------------------------------------------------------------------------

--- a/src/galenet/training/trainer.py
+++ b/src/galenet/training/trainer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Iterable, Iterator, Tuple
 
@@ -11,7 +12,7 @@ from torch.utils.data import DataLoader
 
 
 class Trainer:
-    """Simple trainer handling optimization and checkpointing."""
+    """Trainer handling optimization, logging and checkpointing."""
 
     def __init__(
         self,
@@ -19,21 +20,28 @@ class Trainer:
         optimizer: optim.Optimizer,
         loss_fn: nn.Module | None = None,
         device: torch.device | str = "cpu",
+        grad_accum_steps: int = 1,
+        logger: logging.Logger | None = None,
     ) -> None:
         self.model = model.to(device)
         self.optimizer = optimizer
         self.loss_fn = loss_fn or nn.MSELoss()
         self.device = torch.device(device)
+        self.grad_accum_steps = int(max(1, grad_accum_steps))
+        self.logger = logger or logging.getLogger(__name__)
 
     # ------------------------------------------------------------------
-    def train(self, dataloader: DataLoader, epochs: int = 1) -> Iterator[float]:
+    def train(
+        self, dataloader: DataLoader, epochs: int = 1, start_epoch: int = 0
+    ) -> Iterator[float]:
         """Yield average loss for each epoch."""
 
-        for _ in range(epochs):
+        for epoch in range(start_epoch, start_epoch + epochs):
             self.model.train()
             total = 0.0
             count = 0
-            for batch in dataloader:
+            self.optimizer.zero_grad()
+            for step, batch in enumerate(dataloader, 1):
                 if isinstance(batch, (list, tuple)):
                     inputs, targets = batch[0], batch[1]
                 else:  # pragma: no cover - defensive
@@ -41,32 +49,45 @@ class Trainer:
                 inputs = inputs.to(self.device, dtype=torch.float32)
                 targets = targets.to(self.device, dtype=torch.float32)
 
-                self.optimizer.zero_grad()
                 preds = self.model(inputs)
-                loss = self.loss_fn(preds, targets)
+                loss = self.loss_fn(preds, targets) / self.grad_accum_steps
                 loss.backward()
-                self.optimizer.step()
 
-                total += float(loss.item())
+                if step % self.grad_accum_steps == 0:
+                    self.optimizer.step()
+                    self.optimizer.zero_grad()
+
+                total += float(loss.item()) * self.grad_accum_steps
                 count += 1
-            yield total / max(count, 1)
+            if count % self.grad_accum_steps != 0:
+                self.optimizer.step()
+                self.optimizer.zero_grad()
+
+            avg = total / max(count, 1)
+            self.logger.info("epoch %d loss=%.6f", epoch + 1, avg)
+            yield avg
 
     # ------------------------------------------------------------------
-    def save_checkpoint(self, path: str | Path) -> None:
+    def save_checkpoint(self, path: str | Path, epoch: int = 0) -> None:
         """Persist model and optimizer state to ``path``."""
 
         ckpt = {
             "model": self.model.state_dict(),
             "optimizer": self.optimizer.state_dict(),
+            "epoch": int(epoch),
         }
         torch.save(ckpt, Path(path))
 
-    def load_checkpoint(self, path: str | Path) -> None:
-        """Load model and optimizer state from ``path``."""
+    def load_checkpoint(self, path: str | Path) -> int:
+        """Load model and optimizer state from ``path``.
+
+        Returns the epoch stored in the checkpoint.
+        """
 
         ckpt = torch.load(Path(path), map_location=self.device)
         self.model.load_state_dict(ckpt["model"])
         self.optimizer.load_state_dict(ckpt["optimizer"])
+        return int(ckpt.get("epoch", 0))
 
 
 __all__ = ["Trainer"]

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -17,8 +17,14 @@ import xarray as xr
 # Add src to path
 sys.path.append(str(Path(__file__).parent.parent / 'src'))
 
-# Stub out heavy training/torch dependencies for lightweight tests
-sys.modules.setdefault("torch", SimpleNamespace())
+# Stub out heavy training/torch dependencies for lightweight tests when torch
+# is unavailable.  If torch is installed we use the real library so other tests
+# can rely on it.
+try:  # pragma: no cover - exercised indirectly
+    import torch  # noqa: F401
+except Exception:  # pragma: no cover - executed when torch missing
+    sys.modules.setdefault("torch", SimpleNamespace())
+
 training_stub = SimpleNamespace(HurricaneDataset=None, Trainer=None, mse_loss=None)
 sys.modules.setdefault("galenet.training", training_stub)
 

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -12,7 +12,6 @@ from omegaconf import OmegaConf
 
 # Ensure src is on the path
 sys.path.append(str(Path(__file__).parent.parent / "src"))
-
 from galenet.inference.pipeline import GaleNetPipeline  # noqa: E402
 from galenet.models.graphcast import GraphCastModel  # noqa: E402
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,18 +1,22 @@
 import sys
 from pathlib import Path
 
-import pandas as pd
 import numpy as np
-import torch
+import pandas as pd
 
 sys.path.append(str(Path(__file__).parent.parent / "src"))
+# Ensure any stubs from other tests are removed before importing
+import torch
+sys.modules.pop("galenet.training", None)
 from galenet.training import HurricaneDataset, Trainer, create_dataloader
 
 
 class DummyPipeline:
     """Minimal stand-in for :class:`HurricaneDataPipeline`."""
 
-    def load_hurricane_for_training(self, storm_id, include_era5=False, patch_size: float = 25.0):
+    def load_hurricane_for_training(
+        self, storm_id: str, include_era5: bool = False, patch_size: float = 25.0
+    ):
         times = pd.date_range("2020-01-01", periods=5, freq="H")
         values = np.arange(1, 6, dtype=float)
         df = pd.DataFrame(
@@ -24,27 +28,49 @@ class DummyPipeline:
                 "min_pressure": values,
             }
         )
-        return {"track": df}
+        data = {"track": df}
+        if include_era5:
+            # Simple 1D ERA5 feature for each timestep
+            data["era5"] = np.arange(len(times), dtype=np.float32).reshape(len(times), 1)
+        return data
 
 
 def test_dataset_iteration() -> None:
     pipeline = DummyPipeline()
-    dataset = HurricaneDataset(pipeline, ["TEST"], window=2, include_era5=False)
+    dataset = HurricaneDataset(
+        pipeline, ["TEST"], sequence_window=2, forecast_window=1, include_era5=False
+    )
 
     assert len(dataset) == 3
-    seq, target = dataset[0]
+    seq, target = next(iter(dataset))
     assert seq.shape == (2, 4)
-    assert target.shape == (4,)
+    assert target.shape == (1, 4)
 
     loader = create_dataloader(dataset, batch_size=2, shuffle=False)
     batch_seq, batch_target = next(iter(loader))
     assert batch_seq.shape == (2, 2, 4)
-    assert batch_target.shape == (2, 4)
+    assert batch_target.shape == (2, 1, 4)
+
+
+def test_dataset_with_era5() -> None:
+    pipeline = DummyPipeline()
+    dataset = HurricaneDataset(
+        pipeline, ["TEST"], sequence_window=2, forecast_window=1, include_era5=True
+    )
+
+    seq, target, patch = next(iter(dataset))
+    assert patch.shape == (1, 1)
+
+    loader = create_dataloader(dataset, batch_size=2, shuffle=False)
+    batch_seq, batch_target, batch_patch = next(iter(loader))
+    assert batch_patch.shape == (2, 1, 1)
 
 
 def test_trainer_single_step_reduces_loss() -> None:
     pipeline = DummyPipeline()
-    dataset = HurricaneDataset(pipeline, ["TEST"], window=1, include_era5=False)
+    dataset = HurricaneDataset(
+        pipeline, ["TEST"], sequence_window=1, forecast_window=1, include_era5=False
+    )
     loader = create_dataloader(dataset, batch_size=1, shuffle=False)
 
     model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 4, bias=False))
@@ -54,7 +80,9 @@ def test_trainer_single_step_reduces_loss() -> None:
 
     batch_inputs, batch_targets = next(iter(loader))
     with torch.no_grad():
-        initial = torch.nn.functional.mse_loss(model(batch_inputs), batch_targets).item()
+        initial = torch.nn.functional.mse_loss(
+            model(batch_inputs), batch_targets
+        ).item()
 
     list(trainer.train(loader, epochs=1))
 
@@ -65,10 +93,10 @@ def test_trainer_single_step_reduces_loss() -> None:
 
 
 def test_trainer_updates_weights() -> None:
-    """Weights should change after a training epoch."""
-
     pipeline = DummyPipeline()
-    dataset = HurricaneDataset(pipeline, ["TEST"], window=1, include_era5=False)
+    dataset = HurricaneDataset(
+        pipeline, ["TEST"], sequence_window=1, forecast_window=1, include_era5=False
+    )
     loader = create_dataloader(dataset, batch_size=1, shuffle=False)
 
     model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 4, bias=False))
@@ -81,3 +109,32 @@ def test_trainer_updates_weights() -> None:
     updated_weights = model[1].weight.detach()
 
     assert not torch.allclose(initial_weights, updated_weights)
+
+
+def test_trainer_checkpoint_restore(tmp_path) -> None:
+    pipeline = DummyPipeline()
+    dataset = HurricaneDataset(
+        pipeline, ["TEST"], sequence_window=1, forecast_window=1, include_era5=False
+    )
+    loader = create_dataloader(dataset, batch_size=1, shuffle=False)
+
+    model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 4, bias=False))
+    torch.nn.init.zeros_(model[1].weight)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = Trainer(model, optimizer)
+
+    list(trainer.train(loader, epochs=1))
+    saved_weights = model[1].weight.detach().clone()
+    ckpt = tmp_path / "ckpt.pt"
+    trainer.save_checkpoint(ckpt, epoch=1)
+
+    with torch.no_grad():
+        model[1].weight.add_(1.0)
+
+    epoch = trainer.load_checkpoint(ckpt)
+    assert epoch == 1
+    assert torch.allclose(model[1].weight, saved_weights)
+
+    list(trainer.train(loader, epochs=1, start_epoch=epoch))
+    assert not torch.allclose(model[1].weight, saved_weights)
+


### PR DESCRIPTION
## Summary
- stream multi-storm training data with optional ERA5 patches and configurable windows
- add metric logging, gradient accumulation, and checkpoint resume to Trainer
- drive training via Hydra config for storms, epochs, and device selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a012854a208326934916fc0222b543