### PR TITLE
Add evaluation CLI with pipeline integration and summary output

### DIFF
--- a/scripts/evaluate_baselines.py
+++ b/scripts/evaluate_baselines.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """CLI for evaluating baseline and model forecasts across storms.
 
-This script expects a JSON file containing a list of storms. Each storm is a
-mapping with a ``track`` key holding a list of ``[lat, lon, intensity]``
-triplets. The first ``--history`` steps of each track are used as input for the
-baselines and the next ``--forecast`` steps are compared against the forecasts
-using the evaluation metrics.  When ``--model-config`` is provided, a
-``GaleNetPipeline`` instance is created and its model is run alongside the
-baselines.
+The tool expects a JSON file containing a list of storms.  Each storm is a
+mapping with an ``id`` field and a ``track`` key holding a list of
+``[lat, lon, intensity]`` triplets.  The first ``--history`` steps of each track
+are used as input for the baselines and the next ``--forecast`` steps are
+compared against the forecasts using the evaluation metrics.  A
+``GaleNetPipeline`` instance is created (using ``--model-config`` if supplied)
+and its model forecasts are evaluated alongside the baselines.  A summary table
+is printed and can optionally be written to a CSV file.
 """
 
 from __future__ import annotations
@@ -16,20 +17,37 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Sequence, Tuple
+import sys
 
 import pandas as pd
 
 import numpy as np
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from galenet.evaluation.baselines import evaluate_baselines
+
 from galenet import GaleNetPipeline
 
 
-def _load_storms(path: Path) -> List[np.ndarray]:
+def _load_storms(path: Path) -> List[Tuple[str, np.ndarray]]:
+    """Load storm tracks from ``path``.
+
+    Each entry in the JSON file should contain an ``id`` and ``track`` field.
+    When ``id`` is missing a numeric identifier is generated.  The return value
+    is a list of ``(storm_id, track_array)`` tuples where ``track_array`` has
+    shape ``(N, 3)`` with latitude, longitude and intensity columns.
+    """
+
     with open(path) as f:
         data = json.load(f)
-    return [np.asarray(storm["track"], dtype=float) for storm in data]
+
+    storms: List[Tuple[str, np.ndarray]] = []
+    for idx, storm in enumerate(data):
+        storm_id = str(storm.get("id", idx))
+        track = np.asarray(storm["track"], dtype=float)
+        storms.append((storm_id, track))
+    return storms
 
 
 def main() -> None:
@@ -51,33 +69,61 @@ def main() -> None:
         default="model",
         help="Name to use for reporting model metrics",
     )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write CSV summary",
+    )
+    parser.add_argument(
+        "--no-model",
+        action="store_true",
+        help="Skip running GaleNetPipeline model forecasts",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
-    storms = _load_storms(args.data)
-    model_forecasts = None
-    if args.model_config is not None:
-        pipeline = GaleNetPipeline(str(args.model_config))
-        model_forecasts = []
-        for storm in storms:
-            history = storm[: args.history]
-            df = pd.DataFrame(history, columns=["latitude", "longitude", "max_wind"])
-            preds = pipeline.model.predict(df, args.forecast, 1)
-            model_forecasts.append(
-                preds[["latitude", "longitude", "max_wind"]].to_numpy()
-            )
 
-    results = evaluate_baselines(
-        storms,
-        args.history,
-        args.forecast,
-        model_forecasts=model_forecasts,
-        model_name=args.model_name,
-    )
-    for baseline, metrics in results.items():
-        logging.info("%s:", baseline)
-        for name, value in metrics.items():
-            logging.info("  %s: %.3f", name, value)
+    try:
+        storms_with_ids = _load_storms(args.data)
+        tracks: Sequence[np.ndarray] = [t for _, t in storms_with_ids]
+
+        model_forecasts = None
+        if not args.no_model:
+            pipeline = GaleNetPipeline(
+                str(args.model_config) if args.model_config else None
+            )
+            model_forecasts = []
+            for storm_id, track in storms_with_ids:
+                logging.info("Running model for storm %s", storm_id)
+                history = track[: args.history]
+                df_hist = pd.DataFrame(
+                    history, columns=["latitude", "longitude", "max_wind"]
+                )
+                preds = pipeline.model.predict(df_hist, args.forecast, 1)
+                model_forecasts.append(
+                    preds[["latitude", "longitude", "max_wind"]].to_numpy()
+                )
+
+        results = evaluate_baselines(
+            tracks,
+            args.history,
+            args.forecast,
+            model_forecasts=model_forecasts,
+            model_name=args.model_name,
+        )
+
+        df = pd.DataFrame(results).T
+        print(df.to_string(float_format=lambda x: f"{x:.3f}"))
+        if args.output is not None:
+            df.to_csv(args.output)
+
+        if df.isna().any().any():
+            raise RuntimeError("NaN encountered in evaluation metrics")
+
+    except Exception as exc:  # pragma: no cover - CLI failure path
+        logging.error("Evaluation failed: %s", exc)
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/src/galenet/utils/config.py
+++ b/src/galenet/utils/config.py
@@ -62,7 +62,10 @@ def get_config(
             OmegaConf.update(config, key, value)
 
     # Set environment variables
-    OmegaConf.register_new_resolver("env", lambda x: os.environ.get(x, ''))
+    try:  # Allow repeated registration in multi-use scenarios
+        OmegaConf.register_new_resolver("env", lambda x: os.environ.get(x, ""))
+    except Exception:  # pragma: no cover - resolver already registered
+        pass
 
     return cast(DictConfig, config)
 

--- a/tests/test_evaluation_baselines.py
+++ b/tests/test_evaluation_baselines.py
@@ -1,12 +1,16 @@
+import json
+import subprocess
 import sys
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
+import yaml
 
 sys.path.append(str(Path(__file__).parent.parent / "src" / "galenet"))
 
-from evaluation.baselines import run_baselines, evaluate_baselines
+from evaluation.baselines import evaluate_baselines, run_baselines
 from evaluation.metrics import compute_metrics
 
 
@@ -194,5 +198,90 @@ def test_evaluate_baselines_with_model():
         expected_track_model, rel=1e-4
     )
     assert summary["model"]["intensity_mae"] == pytest.approx(
-        expected_intensity_model, rel=1e-4
+    expected_intensity_model, rel=1e-4
     )
+
+
+def test_cli_evaluate_baselines(tmp_path):
+    storms = [
+        {
+            "id": "S1",
+            "track": [
+                [0.0, 0.0, 40.0],
+                [1.0, 1.0, 42.0],
+                [2.0, 2.0, 44.0],
+                [3.0, 3.0, 46.0],
+                [4.0, 4.0, 48.0],
+            ],
+        },
+        {
+            "id": "S2",
+            "track": [
+                [5.0, 5.0, 30.0],
+                [6.0, 5.0, 32.0],
+                [7.0, 5.0, 34.0],
+                [8.0, 5.0, 36.0],
+                [9.0, 5.0, 38.0],
+            ],
+        },
+    ]
+
+    data_path = tmp_path / "storms.json"
+    with open(data_path, "w") as f:
+        json.dump(storms, f)
+
+    # Minimal config used by GaleNetPipeline and downstream loaders
+    config = {
+        "project": {"name": "test"},
+        "logging": {"level": "INFO"},
+        "data": {
+            "hurdat2_path": "dummy",
+            "ibtracs_path": "dummy",
+            "era5_cache_dir": "dummy",
+        },
+        "model": {"name": "hurricane_ensemble"},
+        "inference": {"time_step": 1},
+        "training": {"epochs": 1},
+    }
+    with open(tmp_path / "default_config.yaml", "w") as f:
+        yaml.safe_dump(config, f)
+
+    csv_path = tmp_path / "summary.csv"
+    cmd = [
+        sys.executable,
+        str(Path(__file__).parent.parent / "scripts" / "evaluate_baselines.py"),
+        str(data_path),
+        "--history",
+        "3",
+        "--forecast",
+        "2",
+        "--output",
+        str(csv_path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=tmp_path)
+    assert proc.returncode == 0, proc.stderr
+
+    df = pd.read_csv(csv_path, index_col=0)
+    tracks = [np.asarray(s["track"], dtype=float) for s in storms]
+    model_forecasts = [
+        run_baselines(t[:3], 2, baselines=["persistence"])["persistence"]
+        for t in tracks
+    ]
+    expected = pd.DataFrame(
+        evaluate_baselines(
+            tracks,
+            history_steps=3,
+            forecast_steps=2,
+            model_forecasts=model_forecasts,
+            model_name="model",
+        )
+    ).T
+
+    for name in ["persistence", "model"]:
+        assert df.loc[name, "track_error"] == pytest.approx(
+            expected.loc[name, "track_error"], rel=1e-4
+        )
+        assert df.loc[name, "intensity_mae"] == pytest.approx(
+            expected.loc[name, "intensity_mae"], rel=1e-4
+        )
+


### PR DESCRIPTION
## Summary
- expand evaluation CLI to run GaleNetPipeline forecasts across storms, aggregate metrics and optionally export CSV
- handle evaluation errors with non-zero exit code and allow skipping model
- add CLI-based evaluation test and fix config resolver to tolerate repeated registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07e1db6808326b4401e01ddccacf8