### PR TITLE
Support multi-storm training batches and checkpoint resume

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -54,8 +54,11 @@ def main(cfg: DictConfig) -> None:
 
     # Training loop --------------------------------------------------------
     epochs = cfg.training.get("epochs", 1)
-    for epoch, loss in enumerate(trainer.train(loader, epochs=epochs), 1):
-        log.info("epoch %d loss=%.6f", epoch, loss)
+    resume = cfg.training.get("resume_from")
+    for epoch, metrics in enumerate(
+        trainer.train(loader, epochs=epochs, resume_from=resume), 1
+    ):
+        log.info("epoch %d %s", epoch, " ".join(f"{k}={v:.6f}" for k, v in metrics.items()))
         trainer.save_checkpoint(ckpt_dir / f"epoch_{epoch}.pt", epoch=epoch)
 
 

--- a/src/galenet/training/datasets.py
+++ b/src/galenet/training/datasets.py
@@ -16,12 +16,15 @@ TrackTriplet = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 
 
 class HurricaneDataset(IterableDataset[Tuple[torch.Tensor, ...]]):
-    """Stream track windows across multiple storms.
+    """Stream synchronized track windows across multiple storms.
 
-    The dataset yields tuples of ``(sequence, target)`` or
-    ``(sequence, target, era5_patch)`` depending on the ``include_era5``
-    flag. ``sequence`` spans ``sequence_window`` observations while ``target``
-    contains ``forecast_window`` future observations.
+    The dataset yields tuples of ``(sequence_batch, target_batch)`` or
+    ``(sequence_batch, target_batch, era5_batch)`` where each batch contains
+    windows for **all** storms provided. ``sequence_batch`` has shape
+    ``(num_storms, sequence_window, features)`` and ``target_batch`` has shape
+    ``(num_storms, forecast_window, features)``. If ``include_era5`` is true an
+    additional tensor with shape ``(num_storms, forecast_window, era5_features)``
+    is returned.
     """
 
     def __init__(
@@ -39,60 +42,77 @@ class HurricaneDataset(IterableDataset[Tuple[torch.Tensor, ...]]):
         self.include_era5 = bool(include_era5)
 
         # Pre-compute the total length for __len__ without storing samples.
-        self._length = 0
+        lengths: List[int] = []
         cols = ["latitude", "longitude", "max_wind", "min_pressure"]
         for storm_id in self.storms:
             data = self.pipeline.load_hurricane_for_training(storm_id, include_era5=False)
             track = data["track"].sort_values("timestamp").reset_index(drop=True)
             arr = track[cols].to_numpy(dtype=np.float32)
-            self._length += max(
-                len(arr) - self.sequence_window - self.forecast_window + 1, 0
+            lengths.append(
+                max(len(arr) - self.sequence_window - self.forecast_window + 1, 0)
             )
+        self._length = min(lengths) if lengths else 0
 
     # ------------------------------------------------------------------
     def __iter__(self) -> Iterator[Tuple[torch.Tensor, ...]]:
         cols = ["latitude", "longitude", "max_wind", "min_pressure"]
+        tracks: List[np.ndarray] = []
+        era5_list: List[np.ndarray | None] = []
         for storm_id in self.storms:
             data = self.pipeline.load_hurricane_for_training(
                 storm_id, include_era5=self.include_era5
             )
             track = data["track"].sort_values("timestamp").reset_index(drop=True)
-            arr = track[cols].to_numpy(dtype=np.float32)
+            tracks.append(track[cols].to_numpy(dtype=np.float32))
 
-            era5 = data.get("era5") if self.include_era5 else None
-            if era5 is not None:
-                try:
-                    era5_arr = np.asarray(era5)
-                except Exception:  # pragma: no cover - very defensive
-                    era5_arr = np.asarray(getattr(era5, "to_array")())
+            if self.include_era5:
+                era5 = data.get("era5")
+                if era5 is not None:
+                    try:
+                        era5_arr = np.asarray(era5)
+                    except Exception:  # pragma: no cover - very defensive
+                        era5_arr = np.asarray(getattr(era5, "to_array")())
+                else:
+                    era5_arr = None
+                era5_list.append(era5_arr)
             else:
-                era5_arr = None
+                era5_list.append(None)
 
-            limit = len(arr) - self.sequence_window - self.forecast_window + 1
-            for i in range(max(limit, 0)):
-                seq = torch.from_numpy(
-                    arr[i : i + self.sequence_window]
-                )
-                target = torch.from_numpy(
-                    arr[
-                        i
-                        + self.sequence_window : i
-                        + self.sequence_window
-                        + self.forecast_window
-                    ]
-                )
-                if era5_arr is not None:
-                    patch = torch.from_numpy(
-                        era5_arr[
+        limit = self._length
+        for i in range(max(limit, 0)):
+            seq_batch: List[torch.Tensor] = []
+            tgt_batch: List[torch.Tensor] = []
+            era5_batch: List[torch.Tensor] | None = [] if self.include_era5 else None
+            for arr, era5_arr in zip(tracks, era5_list):
+                seq_batch.append(torch.from_numpy(arr[i : i + self.sequence_window]))
+                tgt_batch.append(
+                    torch.from_numpy(
+                        arr[
                             i
                             + self.sequence_window : i
                             + self.sequence_window
                             + self.forecast_window
                         ]
                     )
-                    yield (seq, target, patch)
-                else:
-                    yield (seq, target)
+                )
+                if era5_batch is not None and era5_arr is not None:
+                    era5_batch.append(
+                        torch.from_numpy(
+                            era5_arr[
+                                i
+                                + self.sequence_window : i
+                                + self.sequence_window
+                                + self.forecast_window
+                            ]
+                        )
+                    )
+            seq_tensor = torch.stack(seq_batch)
+            tgt_tensor = torch.stack(tgt_batch)
+            if era5_batch is not None:
+                era5_tensor = torch.stack(era5_batch)
+                yield (seq_tensor, tgt_tensor, era5_tensor)
+            else:
+                yield (seq_tensor, tgt_tensor)
 
     # ------------------------------------------------------------------
     def __len__(self) -> int:  # pragma: no cover - trivial


### PR DESCRIPTION
## Summary
- extend HurricaneDataset to batch windows across multiple storms and include optional ERA5 patches
- enhance Trainer with metric logging, resume-from-checkpoint, and extra input handling
- expose device selection and resume options in training script and add tests

## Testing
- `pytest tests/test_training.py -q`
- `pytest -q` *(fails: function '_has_torch_function' already has a docstring)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ce8943883268a8862ad615869fb