### PR TITLE
Add metric logging and validation to trainer

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -103,6 +103,8 @@ training:
   forecast_window: 1
   include_era5: false
   shuffle: true
+  resume_from: null
+  val_storms: []
   
   # Scheduler
   scheduler:

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -38,28 +38,67 @@ def main(cfg: DictConfig) -> None:
         shuffle=cfg.training.get("shuffle", True),
     )
 
+    val_loader = None
+    val_storms = cfg.training.get("val_storms")
+    if val_storms:
+        val_dataset = HurricaneDataset(
+            pipeline,
+            val_storms,
+            sequence_window=cfg.training.get("sequence_window", 1),
+            forecast_window=cfg.training.get("forecast_window", 1),
+            include_era5=cfg.training.get("include_era5", False),
+        )
+        val_loader = create_dataloader(
+            val_dataset,
+            batch_size=cfg.training.get("batch_size", 1),
+            shuffle=False,
+        )
+
     # Model/optimizer ------------------------------------------------------
     model = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(4, 4))
     optimizer = torch.optim.Adam(model.parameters(), lr=cfg.training.learning_rate)
-    trainer = Trainer(
-        model,
-        optimizer,
-        device=cfg.project.get("device", "cpu"),
-        grad_accum_steps=cfg.training.get("gradient_accumulation_steps", 1),
-    )
 
     # Checkpoint directory
     ckpt_dir = Path(cfg.get("checkpoint_dir", "checkpoints"))
     ckpt_dir.mkdir(parents=True, exist_ok=True)
 
+    trainer = Trainer(
+        model,
+        optimizer,
+        device=cfg.project.get("device", "cpu"),
+        grad_accum_steps=cfg.training.get("gradient_accumulation_steps", 1),
+        metrics_file=ckpt_dir / cfg.get("metrics_file", "metrics.jsonl"),
+    )
+
     # Training loop --------------------------------------------------------
     epochs = cfg.training.get("epochs", 1)
     resume = cfg.training.get("resume_from")
+    early_cfg = cfg.training.get("early_stopping")
+    patience = early_cfg.get("patience") if early_cfg else None
+    min_delta = early_cfg.get("min_delta", 0.0) if early_cfg else 0.0
+    best = float("inf")
+    wait = 0
     for epoch, metrics in enumerate(
-        trainer.train(loader, epochs=epochs, resume_from=resume), 1
+        trainer.train(
+            loader,
+            epochs=epochs,
+            resume_from=resume,
+            val_dataloader=val_loader,
+        ),
+        1,
     ):
         log.info("epoch %d %s", epoch, " ".join(f"{k}={v:.6f}" for k, v in metrics.items()))
         trainer.save_checkpoint(ckpt_dir / f"epoch_{epoch}.pt", epoch=epoch)
+        if patience is not None:
+            monitored = metrics.get("val_loss", metrics.get("train_loss", float("inf")))
+            if monitored + min_delta < best:
+                best = monitored
+                wait = 0
+            else:
+                wait += 1
+                if wait >= patience:
+                    log.info("Early stopping triggered at epoch %d", epoch)
+                    break
 
 
 if __name__ == "__main__":

--- a/src/galenet/training/trainer.py
+++ b/src/galenet/training/trainer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Iterator
@@ -22,6 +23,7 @@ class Trainer:
         device: torch.device | str = "cpu",
         grad_accum_steps: int = 1,
         logger: logging.Logger | None = None,
+        metrics_file: str | Path | None = None,
     ) -> None:
         self.model = model.to(device)
         self.optimizer = optimizer
@@ -29,6 +31,9 @@ class Trainer:
         self.device = torch.device(device)
         self.grad_accum_steps = int(max(1, grad_accum_steps))
         self.logger = logger or logging.getLogger(__name__)
+        self.metrics_file = Path(metrics_file) if metrics_file is not None else None
+        if self.metrics_file is not None:
+            self.metrics_file.parent.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------
     def train(
@@ -37,11 +42,15 @@ class Trainer:
         epochs: int = 1,
         start_epoch: int = 0,
         resume_from: str | Path | None = None,
+        val_dataloader: DataLoader | None = None,
     ) -> Iterator[dict]:
         """Yield metrics for each epoch.
 
         If ``resume_from`` is provided, the trainer will load the checkpoint
-        before starting training and continue from the stored epoch.
+        before starting training and continue from the stored epoch. If
+        ``val_dataloader`` is supplied, a validation loop is run after each
+        training epoch and the resulting loss is returned under ``val_loss``.
+        Training metrics are stored under ``train_loss``.
         """
 
         if resume_from is not None:
@@ -76,11 +85,35 @@ class Trainer:
                 self.optimizer.zero_grad()
 
             avg = total / max(count, 1)
-            metrics = {"loss": avg}
+            metrics = {"train_loss": avg}
+
+            if val_dataloader is not None:
+                self.model.eval()
+                val_total = 0.0
+                val_count = 0
+                with torch.no_grad():
+                    for batch in val_dataloader:
+                        if isinstance(batch, (list, tuple)):
+                            v_inputs, v_targets, *v_extras = batch
+                        else:  # pragma: no cover - defensive
+                            v_inputs, v_targets, *v_extras = batch, None, []  # type: ignore[misc]
+                        v_inputs = v_inputs.to(self.device, dtype=torch.float32)
+                        v_targets = v_targets.to(self.device, dtype=torch.float32)
+                        v_extras = [e.to(self.device, dtype=torch.float32) for e in v_extras]
+                        v_preds = self.model(v_inputs, *v_extras)
+                        v_loss = self.loss_fn(v_preds, v_targets)
+                        val_total += float(v_loss.item())
+                        val_count += 1
+                metrics["val_loss"] = val_total / max(val_count, 1)
+
             self.logger.info(
                 "epoch %d " + " ".join(f"{k}={v:.6f}" for k, v in metrics.items()),
                 epoch + 1,
             )
+            if self.metrics_file is not None:
+                record = {"epoch": epoch + 1, **metrics}
+                with self.metrics_file.open("a", encoding="utf8") as f:
+                    f.write(json.dumps(record) + "\n")
             yield metrics
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extend Trainer with optional validation loop and metrics file logging
- expose early stopping and resume config options in train_model script
- add tests for metric logging and validation

## Testing
- `pytest tests/test_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a47a83a5cc8326835c99d10ec2e885