### PR TITLE
docs: note GraphCast placeholder and roadmap

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -6,13 +6,13 @@ This document provides a quick snapshot of GaleNet's progress and what's next.
 - Core package structure with testing and packaging helpers.
 - Loaders for HURDAT2 and IBTrACS hurricane tracks.
 - ERA5 patch extraction and preprocessing utilities.
-- Baseline evaluation script and metrics.
+- Baseline training and evaluation scripts with metrics.
 - Installation, data pipeline, architecture, training, and API documentation.
 - Tutorial notebooks demonstrating basic workflows.
-- Preliminary GraphCast integration hooks.
+- Placeholder GraphCast hooks for future integration.
 
 ## Remaining Milestones
-- Finalize GraphCast integration into the data pipeline.
+- Replace placeholder GraphCast hooks with full integration into the data pipeline.
 - Extend training loop for GraphCast/Pangu-based models.
 - Publish comprehensive evaluation guide and usage examples.
 - **Upcoming**

--- a/README.md
+++ b/README.md
@@ -7,14 +7,25 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-GaleNet explores AI‑based techniques for tropical cyclone forecasting. The project currently focuses on data pipelines and baseline models while integration with weather models such as GraphCast and Pangu‑Weather remains under active development.
+GaleNet explores AI‑based techniques for tropical cyclone forecasting. The project currently focuses on data pipelines, baseline training/evaluation scripts, and placeholder GraphCast hooks while full integration with weather models such as GraphCast and Pangu‑Weather remains under active development.
 
 ## 🌟 Key Features
 
 - **Hurricane Data Pipeline** – loaders for HURDAT2, IBTrACS, and optional ERA5 patches.
 - **Baseline Training & Evaluation Scripts** – minimal examples for model experimentation.
+- **GraphCast Placeholder** – stub weights and hooks to prototype future GraphCast integration.
 - **Hydra Configuration** – reproducible experiments managed through YAML configs.
 - **Modular Design** – architecture prepared for future GraphCast and Pangu‑Weather integration.
+
+## 🗺️ Roadmap
+
+Phase 1 focuses on establishing the foundation for future work:
+
+- Data loaders for HURDAT2/IBTrACS and optional ERA5 patches
+- Baseline training and evaluation scripts
+- Placeholder GraphCast hooks
+
+See [PROJECT_STATUS.md](PROJECT_STATUS.md) for the full list of milestones and progress updates.
 
 ## 🚀 Quick Start
 
@@ -140,8 +151,8 @@ docker run --gpus all -p 8000:8000 galenet:latest
 ### Phase 1: Foundation ✅ **In Progress**
 - [x] Project structure and environment setup
 - [x] Data pipeline with HURDAT2/IBTrACS loaders
-- [x] Baseline evaluation script
-- [ ] GraphCast integration and extended docs
+- [x] Baseline training and evaluation scripts
+- [ ] Replace placeholder GraphCast hooks with full integration and extended docs
 
 ### Phase 2: Model Development 📃 **Planned**
 - [ ] CNN‑Transformer models

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -20,3 +20,6 @@ Key classes and functions exposed at the package level.
 - `GaleNetPipeline` – high‑level interface for generating hurricane forecasts.
 
 Refer to the source code in `src/galenet/` for full details on each component.
+
+See the [Data Pipeline](data_pipeline.md), [Training Guide](training.md), and
+[Evaluation Guide](evaluation.md) for end-to-end examples.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,9 @@ GaleNet combines classic hurricane science with modern deep learning.
 
 - **Data Pipeline** – normalizes HURDAT2/IBTrACS tracks and optionally merges
   ERA5 reanalysis patches.
-- **Neural Network Core** – placeholder network used during prototyping; future
-  versions will integrate GraphCast and Pangu‑Weather backbones.
+- **Neural Network Core** – minimal network with optional placeholder GraphCast
+  features; full GraphCast and Pangu‑Weather backbones are planned for later
+  phases.
 - **Inference Pipeline** – the `GaleNetPipeline` class wraps preprocessing and
   model execution to deliver track forecasts.
 
@@ -19,3 +20,6 @@ GaleNet combines classic hurricane science with modern deep learning.
    overridden via command‑line arguments.
 3. **Reproducibility** – training scripts log checkpoints and configuration so
    experiments can be reproduced.
+
+See the [Training Guide](training.md) for how models are trained and the
+[Evaluation Guide](evaluation.md) for benchmarking approaches.

--- a/docs/training.md
+++ b/docs/training.md
@@ -42,10 +42,10 @@ python scripts/evaluate_baselines.py data/sample_storms.json \
 The command reports track and intensity errors and writes a summary under
 `results/`. See the [Evaluation Guide](evaluation.md) for details.
 
-## GraphCast Integration Notes
+## GraphCast Placeholder
 
-GaleNet includes experimental hooks for initializing weights from the
-GraphCast model. Configure the GraphCast checkpoint in your YAML config:
+Experimental hooks expose placeholder GraphCast weights for upcoming
+integration. Configure the checkpoint in your YAML config:
 
 ```yaml
 model:
@@ -54,5 +54,5 @@ model:
     freeze_backbone: true
 ```
 
-During training, GraphCast features are fused with GaleNet's storm-specific
-heads, enabling fine-tuning on hurricane data.
+The weights are currently stubs and do not provide full GraphCast capability;
+future releases will fuse these features into the training loop.


### PR DESCRIPTION
## Summary
- Document placeholder GraphCast hooks and baseline training/evaluation features
- Add Roadmap pointing to Phase 1 milestones
- Cross-link docs and clarify current implementation scope

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a47f207124832699aafe5605d1b51a