### PR TITLE
Skip training tests when PyTorch is unavailable

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,13 +4,14 @@ import json
 
 import numpy as np
 import pandas as pd
+import pytest
 
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 # Ensure any stubs from other tests are removed before importing
 for mod in list(sys.modules):
     if mod.startswith("torch"):
         sys.modules.pop(mod, None)
-import torch
+torch = pytest.importorskip("torch")
 sys.modules.pop("galenet.training", None)
 from galenet.training import HurricaneDataset, Trainer, create_dataloader
 


### PR DESCRIPTION
## Summary
- skip training suite when PyTorch isn't installed using `pytest.importorskip`

## Testing
- `pip install torch -q` *(operation cancelled)*
- `pytest tests/test_graphcast_official.py tests/test_inference_pipeline.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4828c9c848326a4fe140f7281d7cd