### PR TITLE
test: use mocked GraphCast interface

### DIFF
--- a/tests/test_graphcast_official.py
+++ b/tests/test_graphcast_official.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import xarray as xr
 
 # Ensure src is on the path
 sys.path.append(str(Path(__file__).parent.parent / "src"))
@@ -40,6 +41,15 @@ def test_inference_with_real_package(monkeypatch, tmp_path):
     out = model.infer(arr)
     assert np.allclose(out, arr + 1.0)
 
+    da = xr.DataArray(arr, dims=["t", "c"])
+    da_out = model.infer(da)
+    assert isinstance(da_out, xr.DataArray)
+    assert np.allclose(da_out.values, arr + 1.0)
+
     # Autoregressive prediction simply chains calls to infer
     out2 = model.predict(arr, num_steps=2, step=6)
     assert np.allclose(out2, arr + 2.0)
+
+    da_out2 = model.predict(da, num_steps=2, step=6)
+    assert isinstance(da_out2, xr.DataArray)
+    assert np.allclose(da_out2.values, arr + 2.0)

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -185,14 +185,17 @@ def test_graphcast_pipeline_environment_output(monkeypatch, tmp_path, sample_tra
 
     import galenet.models.graphcast as gm
 
-    class DummyGraphCastModel:
-        def __init__(self, *args, **kwargs):
-            pass
+    class DummyModel:
+        def __call__(self, x: np.ndarray) -> np.ndarray:
+            return x + 1.0
 
-        def infer(self, climate):
-            return climate + 1.0
+    class DummyGraphCastModule:
+        @staticmethod
+        def load_checkpoint(path):  # type: ignore[override]
+            return DummyModel()
 
-    monkeypatch.setattr(gm, "GraphCastModel", DummyGraphCastModel)
+    monkeypatch.setattr(gm, "dm_graphcast", DummyGraphCastModule)
+    monkeypatch.setattr(gm, "_GRAPHCAST_AVAILABLE", True)
 
     pipeline = GaleNetPipeline(config_path=CONFIG_PATH)
 


### PR DESCRIPTION
## Summary
- mock GraphCast's official interface in inference pipeline tests
- cover GraphCast wrapper with both NumPy and xarray inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49a6f71808326b22fc596102304be