### PR TITLE
docs: document Pangu-Weather integration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,10 +6,18 @@ GaleNet combines classic hurricane science with modern deep learning.
 
 - **Data Pipeline** – normalizes HURDAT2/IBTrACS tracks and optionally merges
   ERA5 reanalysis patches.
-- **Neural Network Core** – supports a GraphCast backbone for physics‑informed
-  feature extraction; a Pangu‑Weather backbone is planned for later phases.
+- **Neural Network Core** – supports GraphCast and Pangu‑Weather backbones for
+  physics‑informed feature extraction.
 - **Inference Pipeline** – the `GaleNetPipeline` class wraps preprocessing and
   model execution, incorporating GraphCast outputs to guide track forecasts.
+
+### Backbone Options
+
+The backbone is selected via `model.name` in the Hydra configuration:
+
+- `graphcast` uses DeepMind's GraphCast weights and expects 0.25° ERA5 patches.
+- `pangu` enables Microsoft's Pangu‑Weather transformer, which consumes 3D ERA5
+  cubes with wind, temperature, humidity, and geopotential fields.
 
 ## Design Principles
 

--- a/docs/data_pipeline.md
+++ b/docs/data_pipeline.md
@@ -114,3 +114,49 @@ training:
 This configuration instructs the pipeline to download the required ERA5
 variables at 0.25° resolution and provide them to GraphCast during processing.
 
+## Preparing Pangu Inputs
+
+Pangu-Weather ingests a richer 3D ERA5 cube to supply atmospheric context.
+
+1. **Select Variables** – Request the surface and pressure‑level fields needed
+   by Pangu:
+
+   ```yaml
+   data:
+     era5:
+       variables:
+         - "geopotential"
+         - "temperature"
+         - "u_component_of_wind"
+         - "v_component_of_wind"
+         - "specific_humidity"
+         - "mean_sea_level_pressure"
+         - "10m_u_component_of_wind"
+         - "10m_v_component_of_wind"
+         - "2m_temperature"
+       pressure_levels: [1000, 925, 850, 700, 500, 400, 300, 250, 200, 150, 100, 70, 50]
+   ```
+
+2. **Set Resolution** – Extract ERA5 patches on Pangu's 0.25° grid:
+
+   ```yaml
+   model:
+     pangu:
+       resolution: 0.25
+   ```
+
+3. **Enable Pangu** – Activate the backbone and ensure ERA5 fields are passed
+   through the pipeline:
+
+   ```yaml
+   model:
+     name: pangu
+     pangu:
+       checkpoint_path: "models/pangu/params.npz"
+   training:
+     include_era5: true
+   ```
+
+This configuration prepares the required ERA5 data for Pangu during
+preprocessing.
+

--- a/docs/training.md
+++ b/docs/training.md
@@ -75,3 +75,42 @@ python scripts/train_model.py model.name=graphcast \
 ```
 
 This command fine‑tunes GraphCast while training GaleNet's forecasting head.
+
+## Pangu-Weather Model
+
+The Pangu-Weather backbone offers an alternative physics-informed encoder. It
+consumes 3D ERA5 cubes containing wind, temperature, humidity, and geopotential
+fields on 13 pressure levels along with surface variables.
+
+### Required ERA5 Variables
+
+Ensure the data pipeline requests the following fields:
+
+```yaml
+data:
+  era5:
+    variables:
+      - "geopotential"
+      - "temperature"
+      - "u_component_of_wind"
+      - "v_component_of_wind"
+      - "specific_humidity"
+      - "mean_sea_level_pressure"
+      - "10m_u_component_of_wind"
+      - "10m_v_component_of_wind"
+      - "2m_temperature"
+    pressure_levels: [1000, 925, 850, 700, 500, 400, 300, 250, 200, 150, 100, 70, 50]
+```
+
+### Example: Pangu-backed Training
+
+Run a Pangu-supported training session with:
+
+```bash
+python scripts/train_model.py model.name=pangu \
+    model.pangu.checkpoint_path=/path/to/pangu_weights.npz \
+    model.pangu.freeze_backbone=false \
+    training.include_era5=true training.epochs=5
+```
+
+This command fine‑tunes Pangu while training GaleNet's forecasting head.


### PR DESCRIPTION
## Summary
- document Pangu-Weather training setup and required ERA5 variables
- explain Pangu-Weather backbone option in architecture overview
- show ERA5 configuration for preparing Pangu inputs

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4aa4473e08326905557971dda0f9d