### PR TITLE
docs: clarify pangu inference-only usage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,8 @@ GaleNet combines classic hurricane science with modern deep learning.
 
 - **Data Pipeline** – normalizes HURDAT2/IBTrACS tracks and optionally merges
   ERA5 reanalysis patches.
-- **Neural Network Core** – supports GraphCast and Pangu‑Weather backbones for
-  physics‑informed feature extraction.
+- **Neural Network Core** – supports GraphCast and a Pangu‑Weather backbone for
+  physics‑informed feature extraction. Pangu operates in inference mode only.
 - **Inference Pipeline** – the `GaleNetPipeline` class wraps preprocessing and
   model execution, incorporating GraphCast outputs to guide track forecasts.
 
@@ -16,8 +16,9 @@ GaleNet combines classic hurricane science with modern deep learning.
 The backbone is selected via `model.name` in the Hydra configuration:
 
 - `graphcast` uses DeepMind's GraphCast weights and expects 0.25° ERA5 patches.
-- `pangu` enables Microsoft's Pangu‑Weather transformer, which consumes 3D ERA5
-  cubes with wind, temperature, humidity, and geopotential fields.
+- `pangu` enables Microsoft's Pangu‑Weather transformer for inference. It
+  consumes 3D ERA5 cubes with wind, temperature, humidity, and geopotential
+  fields. The pretrained weights remain fixed; fine‑tuning is not supported.
 
 ## Design Principles
 

--- a/docs/data_pipeline.md
+++ b/docs/data_pipeline.md
@@ -116,7 +116,9 @@ variables at 0.25° resolution and provide them to GraphCast during processing.
 
 ## Preparing Pangu Inputs
 
-Pangu-Weather ingests a richer 3D ERA5 cube to supply atmospheric context.
+Pangu-Weather ingests a richer 3D ERA5 cube to supply atmospheric context. The
+backbone is currently used for inference only; training or fine-tuning Pangu is
+not supported.
 
 1. **Select Variables** – Request the surface and pressure‑level fields needed
    by Pangu:
@@ -158,5 +160,5 @@ Pangu-Weather ingests a richer 3D ERA5 cube to supply atmospheric context.
    ```
 
 This configuration prepares the required ERA5 data for Pangu during
-preprocessing.
+preprocessing. The Pangu weights remain fixed and are only used for inference.
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -76,15 +76,16 @@ python scripts/train_model.py model.name=graphcast \
 
 This command fine‑tunes GraphCast while training GaleNet's forecasting head.
 
-## Pangu-Weather Model
+## Pangu-Weather Model (Inference Only)
 
-The Pangu-Weather backbone offers an alternative physics-informed encoder. It
-consumes 3D ERA5 cubes containing wind, temperature, humidity, and geopotential
-fields on 13 pressure levels along with surface variables.
+The Pangu-Weather backbone provides an alternative physics-informed encoder for
+inference. GaleNet uses the pre-trained Pangu weights without fine-tuning; the
+backbone runs in inference mode only.
 
 ### Required ERA5 Variables
 
-Ensure the data pipeline requests the following fields:
+Ensure the data pipeline requests the following fields when running Pangu for
+inference:
 
 ```yaml
 data:
@@ -102,15 +103,5 @@ data:
     pressure_levels: [1000, 925, 850, 700, 500, 400, 300, 250, 200, 150, 100, 70, 50]
 ```
 
-### Example: Pangu-backed Training
-
-Run a Pangu-supported training session with:
-
-```bash
-python scripts/train_model.py model.name=pangu \
-    model.pangu.checkpoint_path=/path/to/pangu_weights.npz \
-    model.pangu.freeze_backbone=false \
-    training.include_era5=true training.epochs=5
-```
-
-This command fine‑tunes Pangu while training GaleNet's forecasting head.
+These variables must be available when invoking the Pangu backbone for
+inference.


### PR DESCRIPTION
## Summary
- remove unsupported Pangu fine-tuning instructions from training guide
- document Pangu backbone as inference-only in architecture and data pipeline guides

## Testing
- `pytest -q` *(fails: No module named 'torch.utils'; 'torch' is not a package)*
- `make lint` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cf0701208326aff218275261d075