### PR TITLE
Clarify Pangu is inference-only

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -10,7 +10,7 @@ This document provides a quick snapshot of GaleNet's progress and what's next.
 - Installation, data pipeline, architecture, training, and API documentation.
 - Tutorial notebooks demonstrating basic workflows.
 - Full GraphCast integration with accompanying training and pipeline docs.
-- Full Pangu-Weather integration with accompanying training and pipeline docs.
+- Full Pangu-Weather inference integration with accompanying pipeline docs.
 
 ## Remaining Milestones
 - Publish comprehensive evaluation guide and usage examples.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-GaleNet explores AI‑based techniques for tropical cyclone forecasting. The project currently focuses on data pipelines, baseline training/evaluation scripts, and full GraphCast and Pangu‑Weather integration.
+GaleNet explores AI‑based techniques for tropical cyclone forecasting. The project currently focuses on data pipelines, baseline training/evaluation scripts, GraphCast training, and Pangu‑Weather inference integration.
 
 ## 🌟 Key Features
 
 - **Hurricane Data Pipeline** – loaders for HURDAT2, IBTrACS, and optional ERA5 patches.
 - **Baseline Training & Evaluation Scripts** – minimal examples for model experimentation.
-- **Full GraphCast & Pangu-Weather Support** – integrated training and data pipelines leveraging GraphCast and Pangu‑Weather; see the [training guide](docs/training.md) and [pipeline docs](docs/data_pipeline.md).
+- **GraphCast Training & Pangu-Weather Inference** – integrated training utilities for GraphCast and an inference pipeline using Pangu‑Weather; see the [training guide](docs/training.md) and [pipeline docs](docs/data_pipeline.md).
 - **Hydra Configuration** – reproducible experiments managed through YAML configs.
 - **Modular Design** – architecture prepared for additional forecasting models.
 
@@ -27,7 +27,7 @@ Phase 1 focuses on establishing the foundation for future work:
 
 ### ✅ Completed
 
-- Full GraphCast and Pangu‑Weather integration with training and pipeline documentation
+- Full GraphCast training and Pangu‑Weather inference integration with pipeline documentation
 
 See [PROJECT_STATUS.md](PROJECT_STATUS.md) for the full list of milestones and progress updates.
 
@@ -162,7 +162,7 @@ docker run --gpus all -p 8000:8000 galenet:latest
 - [x] Data pipeline with HURDAT2/IBTrACS loaders
 - [x] Baseline training and evaluation scripts
 - [x] Full GraphCast integration with extended documentation
-- [x] Full Pangu-Weather integration with extended documentation
+- [x] Full Pangu-Weather inference integration with extended documentation
 
 ### Phase 2: Model Development 📃 **Planned**
 - [ ] CNN‑Transformer models

--- a/docs/data_pipeline.md
+++ b/docs/data_pipeline.md
@@ -117,8 +117,8 @@ variables at 0.25° resolution and provide them to GraphCast during processing.
 ## Preparing Pangu Inputs
 
 Pangu-Weather ingests a richer 3D ERA5 cube to supply atmospheric context. The
-backbone is currently used for inference only; training or fine-tuning Pangu is
-not supported.
+backbone is used for inference only, and GaleNet does not train or update Pangu
+weights.
 
 1. **Select Variables** – Request the surface and pressure‑level fields needed
    by Pangu:

--- a/docs/training.md
+++ b/docs/training.md
@@ -78,9 +78,9 @@ This command fine‑tunes GraphCast while training GaleNet's forecasting head.
 
 ## Pangu-Weather Model (Inference Only)
 
-The Pangu-Weather backbone provides an alternative physics-informed encoder for
-inference. GaleNet uses the pre-trained Pangu weights without fine-tuning; the
-backbone runs in inference mode only.
+The Pangu-Weather backbone provides an alternative physics-informed encoder used
+solely during inference. GaleNet loads the pre-trained Pangu weights but does
+not update them during training.
 
 ### Required ERA5 Variables
 

--- a/notebooks/01_galenet_quickstart.ipy
+++ b/notebooks/01_galenet_quickstart.ipy
@@ -416,7 +416,7 @@
     "\n",
     "Future notebooks will cover:\n",
     "- ERA5 reanalysis data integration\n",
-    "- Model training with GraphCast/Pangu-Weather\n",
+    "- Model training with GraphCast and Pangu-Weather inference\n",
     "- Ensemble forecasting\n",
     "- Performance evaluation against GFS/ECMWF"
    ]


### PR DESCRIPTION
## Summary
- Clarify that Pangu-Weather is used only for inference in the training guide
- Update data pipeline, README, project status, and quickstart notebook to remove Pangu fine-tuning references

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52d4b1bc883269c82e607175d4698