### PR TITLE
docs: mark Pangu implementation in default config

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -49,7 +49,7 @@ data:
 # Model configuration
 model:
   # Model selection
-  name: "graphcast"  # Options: graphcast, pangu (implemented); hurricane_cnn, ensemble planned
+  name: "graphcast"  # Options: graphcast, pangu (implemented); hurricane_cnn (planned), ensemble (planned)
   
   # GraphCast settings
   graphcast:


### PR DESCRIPTION
## Summary
- clarify in `default_config.yaml` that Pangu is implemented and flag other models as planned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a530335c7c8326968712785551c1c1