### PR TITLE
Remove test-data target and update quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,6 @@ test-quick:
 	@echo "Running quick tests..."
 	pytest tests/ -v -k "not slow"
 
-test-data:
-	@echo "Testing data loading..."
-	$(PYTHON) scripts/test_data_loading.py
 
 lint:
 	@echo "Running linters..."
@@ -212,7 +209,7 @@ release-major:
 	bumpversion major
 
 # Quick start
-quickstart: setup install download-data test-data
+quickstart: setup install download-data test
 	@echo ""
 	@echo "GaleNet setup complete! 🌀"
 	@echo ""


### PR DESCRIPTION
## Summary
- remove obsolete `test-data` target
- run standard tests in `quickstart`

## Testing
- `make quickstart` *(fails: conda: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e96ee6948326a01419828fb689fe