### PR TITLE
Fix import sorting in baseline CLI test

### DIFF
--- a/tests/test_evaluate_baselines_cli.py
+++ b/tests/test_evaluate_baselines_cli.py
@@ -2,8 +2,8 @@ import importlib.util
 import os
 import subprocess
 import sys
-from pathlib import Path
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -16,8 +16,8 @@ pytestmark = pytest.mark.skipif(
 )
 
 if pandas_spec and numpy_spec:  # pragma: no branch
-    import pandas as pd
     import numpy as np
+    import pandas as pd
 
 STORM_DATA_CODE = textwrap.dedent(
     """


### PR DESCRIPTION
## Summary
- sort imports in `test_evaluate_baselines_cli.py` so `make lint` passes

## Testing
- `make lint`
- `make test`
- `make quickstart`


------
https://chatgpt.com/codex/tasks/task_e_68a5db772d6083268d3dda16d7bc424c