### PR TITLE
Add physics-based loss functions and docs

### DIFF
--- a/docs/physics_metrics.md
+++ b/docs/physics_metrics.md
@@ -1,0 +1,48 @@
+# Physics-based Metrics
+
+This document defines physical consistency metrics that can be used as loss
+functions during model training.
+
+## Mass Conservation
+Measures how well the predicted density field preserves total mass.
+
+**Definition**
+
+\[
+L_\text{mass} = \left(\sum_i p_i - \sum_i t_i\right)^2
+\]
+where $p_i$ and $t_i$ denote predicted and target density values.
+
+**Calculation**
+1. Sum all elements of the predicted and target density fields.
+2. Compute the squared difference of the two totals.
+
+## Momentum Conservation
+Ensures the integrated momentum of the velocity field matches the target.
+
+**Definition**
+
+\[
+L_\text{mom} = \left(\sum_i \vec{p}_i - \sum_i \vec{t}_i\right)^2
+\]
+where $\vec{p}_i=(u_i, v_i)$ and $\vec{t}_i$ are predicted and target velocity
+vectors.
+
+**Calculation**
+1. Sum the velocity vectors over all grid points for both fields.
+2. Compute the squared Euclidean distance between the totals.
+
+## Kinetic Energy
+Penalises differences in kinetic energy between predicted and target
+velocities.
+
+**Definition**
+
+\[
+L_\text{ke} = \frac{1}{N} \sum_i \left( \tfrac{1}{2}\|\vec{p}_i\|^2 - \tfrac{1}{2}\|\vec{t}_i\|^2 \right)^2
+\]
+where $N$ is the number of grid points.
+
+**Calculation**
+1. Compute kinetic energy $\tfrac{1}{2}(u^2+v^2)$ for each velocity vector.
+2. Subtract target from prediction and compute the mean squared difference.

--- a/src/galenet/training/__init__.py
+++ b/src/galenet/training/__init__.py
@@ -1,7 +1,20 @@
 """Training utilities for GaleNet models."""
 
 from .datasets import HurricaneDataset, create_dataloader
-from .losses import mse_loss
+from .losses import (
+    kinetic_energy_loss,
+    mass_conservation_loss,
+    momentum_conservation_loss,
+    mse_loss,
+)
 from .trainer import Trainer
 
-__all__ = ["HurricaneDataset", "create_dataloader", "mse_loss", "Trainer"]
+__all__ = [
+    "HurricaneDataset",
+    "create_dataloader",
+    "mse_loss",
+    "mass_conservation_loss",
+    "momentum_conservation_loss",
+    "kinetic_energy_loss",
+    "Trainer",
+]

--- a/src/galenet/training/losses.py
+++ b/src/galenet/training/losses.py
@@ -16,6 +16,58 @@ def mse_loss(pred: np.ndarray, target: np.ndarray) -> tuple[float, np.ndarray]:
     """
 
     diff = pred - target
-    loss = float(np.mean(diff ** 2))
+    loss = float(np.mean(diff**2))
     grad = (2.0 / diff.size) * diff
+    return loss, grad
+
+
+def mass_conservation_loss(pred: np.ndarray, target: np.ndarray) -> tuple[float, np.ndarray]:
+    """Squared difference between total predicted and target mass.
+
+    Parameters
+    ----------
+    pred, target:
+        Arrays of identical shape representing density or mass fields.
+    """
+
+    diff = float(np.sum(pred) - np.sum(target))
+    loss = diff**2
+    grad = np.full_like(pred, 2.0 * diff)
+    return loss, grad
+
+
+def momentum_conservation_loss(pred: np.ndarray, target: np.ndarray) -> tuple[float, np.ndarray]:
+    """Squared error between total momentum vectors.
+
+    Parameters
+    ----------
+    pred, target:
+        Arrays with last dimension 2 representing velocity vectors ``(u, v)``.
+    """
+
+    pred_tot = np.sum(pred, axis=tuple(range(pred.ndim - 1)))
+    target_tot = np.sum(target, axis=tuple(range(target.ndim - 1)))
+    diff = pred_tot - target_tot
+    loss = float(np.sum(diff**2))
+    grad = np.zeros_like(pred)
+    grad[..., 0] = 2.0 * diff[0]
+    grad[..., 1] = 2.0 * diff[1]
+    return loss, grad
+
+
+def kinetic_energy_loss(pred: np.ndarray, target: np.ndarray) -> tuple[float, np.ndarray]:
+    """Mean squared error between kinetic energy of ``pred`` and ``target``.
+
+    Parameters
+    ----------
+    pred, target:
+        Arrays with last dimension 2 representing velocity vectors ``(u, v)``.
+    """
+
+    pred_ke = 0.5 * np.sum(pred**2, axis=-1)
+    target_ke = 0.5 * np.sum(target**2, axis=-1)
+    diff = pred_ke - target_ke
+    loss = float(np.mean(diff**2))
+    grad_ke = (2.0 / diff.size) * diff
+    grad = grad_ke[..., None] * pred
     return loss, grad

--- a/tests/test_physics_losses.py
+++ b/tests/test_physics_losses.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Import losses without triggering heavy package imports
+sys.path.append(str(Path(__file__).parent.parent / "src/galenet/training"))
+
+from losses import (  # type: ignore  # noqa: E402
+    kinetic_energy_loss,
+    mass_conservation_loss,
+    momentum_conservation_loss,
+)
+
+
+def test_mass_conservation_loss():
+    pred = np.array([[1.0, 2.0], [3.0, 4.0]])
+    target = np.array([[0.0, 1.0], [1.0, 0.0]])
+    loss, grad = mass_conservation_loss(pred, target)
+    assert loss == pytest.approx(64.0)
+    assert np.all(grad == 16.0)
+
+
+def test_momentum_conservation_loss():
+    pred = np.array([[1.0, 2.0], [3.0, 4.0]])
+    target = np.zeros_like(pred)
+    loss, grad = momentum_conservation_loss(pred, target)
+    assert loss == pytest.approx(52.0)
+    assert np.all(grad[..., 0] == 8.0)
+    assert np.all(grad[..., 1] == 12.0)
+
+
+def test_kinetic_energy_loss():
+    pred = np.array([[2.0, 0.0], [0.0, 2.0]])
+    target = np.array([[1.0, 0.0], [0.0, 1.0]])
+    loss, grad = kinetic_energy_loss(pred, target)
+    assert loss == pytest.approx(2.25)
+    expected_grad = np.array([[3.0, 0.0], [0.0, 3.0]])
+    assert np.allclose(grad, expected_grad)


### PR DESCRIPTION
## Summary
- document mass, momentum, and kinetic energy metrics
- add corresponding loss functions and exports
- test physics losses

## Testing
- `pre-commit run --files docs/physics_metrics.md src/galenet/training/losses.py src/galenet/training/__init__.py tests/test_physics_losses.py`
- `pytest tests/test_physics_losses.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a627fcf53c8326a2720aa9266b19a5