### PR TITLE
ci: fallback to main base ref for pre-commit

### DIFF
--- a/.github/workflows/model-ci.yml
+++ b/.github/workflows/model-ci.yml
@@ -21,7 +21,8 @@ jobs:
           pip install .[dev]
       - name: Run pre-commit on changed files
         run: |
-          files=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD)
+          BASE_REF=${{ github.base_ref || 'main' }}
+          files=$(git diff --name-only --diff-filter=d origin/$BASE_REF...HEAD)
           if [ -n "$files" ]; then
             pre-commit run --files $files --show-diff-on-failure
           else


### PR DESCRIPTION
## Summary
- default to main when `github.base_ref` is empty in pre-commit step

## Testing
- `pre-commit run --files .github/workflows/model-ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a7251a6e088326bb59cd24ca8ddf2f