### PR TITLE
Configure Hurricane CNN training parameters

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -59,7 +59,7 @@ data:
 # Model configuration
 model:
   # Model selection
-  name: "graphcast"  # Options: graphcast, pangu (implemented); hurricane_cnn (planned), ensemble (planned)
+  name: "hurricane_cnn"  # Options: graphcast, pangu (implemented); hurricane_cnn (planned), ensemble (planned)
 
   # GraphCast settings
   graphcast:
@@ -105,11 +105,19 @@ model:
   # Hurricane CNN-Transformer
   # TODO: Implement Hurricane CNN-Transformer model
   hurricane_cnn:
-    encoder_layers: 6
-    decoder_layers: 6
-    hidden_dim: 256
-    num_heads: 8
-    dropout: 0.1
+    encoder_layers: 4
+    decoder_layers: 4
+    encoder_hidden_dim: 256
+    decoder_hidden_dim: 128
+    dropout: 0.2
+    channels:
+      - "sea_surface_temperature"
+      - "10m_u_component_of_wind"
+      - "10m_v_component_of_wind"
+      - "mean_sea_level_pressure"
+      - "ir1"
+      - "ir2"
+      - "water_vapor"
 
   # Ensemble settings
   ensemble:
@@ -124,9 +132,9 @@ model:
 # Training configuration
 training:
   # Basic settings
-  epochs: 100
-  learning_rate: 5e-5
-  weight_decay: 1e-4
+  epochs: 50
+  batch_size: 16
+  sequence_window: 6
   gradient_clip: 1.0
   gradient_accumulation_steps: 8
   # Final Phase 2 storm partitions
@@ -137,19 +145,25 @@ training:
     "AL112015", "AL042016", "AL082017",
     "AL062018", "AL052019"
   ]
-  sequence_window: 1
   forecast_window: 1
   include_era5: false
   shuffle: true
   resume_from: null
+  validation_split: 0.1
   val_storms: ["AL012020", "AL052020", "AL092021", "AL152021"]
   test_storms: []  # All remaining 2022–2023 Atlantic hurricanes
 
-  # Scheduler
+  # Optimization
+  optimizer:
+    name: adam
+    lr: 3e-4
+    weight_decay: 1e-5
+
   scheduler:
     name: "cosine"  # cosine, linear, exponential
     warmup_steps: 1000
     min_lr: 1e-6
+    t_max: 50
 
   # Loss functions
   loss:

--- a/src/galenet/data/__init__.py
+++ b/src/galenet/data/__init__.py
@@ -5,13 +5,13 @@ from .era5 import ERA5Loader
 from .hurdat2 import HURDAT2Loader
 from .ibtracs import IBTrACSLoader
 from .pipeline import HurricaneDataPipeline
-from .satellite import SatelliteLoader
 from .processors import (
     ERA5Preprocessor,
     HurricanePreprocessor,
     create_track_features,
     normalize_track_data,
 )
+from .satellite import SatelliteLoader
 from .validators import (
     HurricaneDataValidator,
     validate_era5_data,

--- a/src/galenet/models/__init__.py
+++ b/src/galenet/models/__init__.py
@@ -1,7 +1,7 @@
 """Model implementations for GaleNet."""
 
 from .graphcast import GraphCastModel
-from .pangu import PanguModel
 from .hurricane_cnn import HurricaneCNN
+from .pangu import PanguModel
 
 __all__ = ["GraphCastModel", "PanguModel", "HurricaneCNN"]

--- a/tests/test_physics_losses.py
+++ b/tests/test_physics_losses.py
@@ -7,11 +7,9 @@ import pytest
 # Import losses without triggering heavy package imports
 sys.path.append(str(Path(__file__).parent.parent / "src/galenet/training"))
 
-from losses import (  # type: ignore  # noqa: E402
-    kinetic_energy_loss,
-    mass_conservation_loss,
-    momentum_conservation_loss,
-)
+from losses import kinetic_energy_loss  # type: ignore  # noqa: E402
+from losses import mass_conservation_loss  # noqa: E402
+from losses import momentum_conservation_loss  # noqa: E402
 
 
 def test_mass_conservation_loss():


### PR DESCRIPTION
## Summary
- switch default model to `hurricane_cnn`
- expand hurricane CNN configuration with layers, hidden dims, dropout, and channel inputs
- tune training defaults for hurricane CNN including Adam optimizer, cosine scheduler, and validation split
- sort imports to satisfy linters

## Testing
- `pytest -q`
- `pre-commit run --files src/galenet/data/__init__.py src/galenet/models/__init__.py src/galenet/training/__init__.py tests/test_physics_losses.py tests/test_training.py` *(fails: files were reformatted by black, subsequently fixed)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75fa7f0a0832684ad147469a21a98