### PR TITLE
Add HurricaneCNN branch and track-image dataset support

### DIFF
--- a/tests/test_train_model_pangu.py
+++ b/tests/test_train_model_pangu.py
@@ -86,7 +86,9 @@ def test_train_model_runs_one_epoch(monkeypatch, tmp_path):
                 self.inner = pangu.PanguModel(ckpt)
                 self.dummy = torch.nn.Parameter(torch.zeros(1))
 
-            def forward(self, era5: torch.Tensor) -> torch.Tensor:
+            def forward(
+                self, _tracks: torch.Tensor, era5: torch.Tensor
+            ) -> torch.Tensor:
                 shape = (era5.shape[0], era5.shape[1], 1, 4)
                 return torch.zeros(shape, dtype=torch.float32) + self.dummy
 


### PR DESCRIPTION
## Summary
- add HurricaneCNN model option that accepts track and image inputs
- extend `HurricaneDataset` to yield track histories with image patches
- route new inputs through training script with checkpoint and metrics handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78aff6ea08326be39773012ce192e