### PR TITLE
Add RMSE evaluation metrics for track and intensity

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -214,9 +214,11 @@ inference:
 evaluation:
   metrics:
     - "track_error"
+    - "track_rmse"
     - "along_track_error"
     - "cross_track_error"
     - "intensity_mae"
+    - "intensity_rmse"
     - "rapid_intensification_skill"
 
   baselines:

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -8,30 +8,41 @@ import pytest
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 
 from galenet.evaluation.metrics import along_track_error  # noqa: E402
-from galenet.evaluation.metrics import (compute_metrics,  # noqa: E402
-                                        cross_track_error, intensity_mae,
-                                        rapid_intensification_skill,
-                                        track_error)
+from galenet.evaluation.metrics import (  # noqa: E402
+    compute_metrics,
+    cross_track_error,
+    intensity_mae,
+    intensity_rmse,
+    rapid_intensification_skill,
+    track_error,
+    track_rmse,
+)
 
 
 def _haversine(lat1, lon1, lat2, lon2):
     r = 6371.0
     dlat = np.radians(lat2 - lat1)
     dlon = np.radians(lon2 - lon1)
-    a = np.sin(dlat / 2) ** 2 + np.cos(np.radians(lat1)) * np.cos(
-        np.radians(lat2)
-    ) * np.sin(dlon / 2) ** 2
+    a = (
+        np.sin(dlat / 2) ** 2
+        + np.cos(np.radians(lat1)) * np.cos(np.radians(lat2)) * np.sin(dlon / 2) ** 2
+    )
     return 2 * r * np.arcsin(np.sqrt(a))
 
 
 def test_metric_computations():
     truth = np.array([[0.0, 0.0], [0.0, 1.0]])
     pred = np.array([[0.0, 0.0], [1.0, 1.5]])
-    expected_track = np.mean([
-        0.0,
-        _haversine(1.0, 1.5, 0.0, 1.0),
-    ])
+    expected_track = np.mean(
+        [
+            0.0,
+            _haversine(1.0, 1.5, 0.0, 1.0),
+        ]
+    )
     assert track_error(pred, truth) == pytest.approx(expected_track, rel=1e-4)
+
+    expected_track_rmse = np.sqrt(np.mean([0.0**2, _haversine(1.0, 1.5, 0.0, 1.0) ** 2]))
+    assert track_rmse(pred, truth) == pytest.approx(expected_track_rmse, rel=1e-4)
 
     assert along_track_error(pred, truth) == pytest.approx(55.5, rel=0.02)
     assert cross_track_error(pred, truth) == pytest.approx(111.0, rel=0.02)
@@ -39,22 +50,28 @@ def test_metric_computations():
     intens_pred = np.array([40.0, 45.0, 50.0, 55.0, 65.0, 90.0])
     intens_true = np.array([40.0, 45.0, 50.0, 55.0, 70.0, 75.0])
     assert intensity_mae(intens_pred, intens_true) == pytest.approx(3.3333, rel=1e-4)
-    assert rapid_intensification_skill(intens_pred, intens_true) == pytest.approx(
-        2 / 3, rel=1e-4
+    expected_intensity_rmse = np.sqrt(np.mean((intens_pred - intens_true) ** 2))
+    assert intensity_rmse(intens_pred, intens_true) == pytest.approx(
+        expected_intensity_rmse, rel=1e-4
     )
+    assert rapid_intensification_skill(intens_pred, intens_true) == pytest.approx(2 / 3, rel=1e-4)
 
     results = compute_metrics(pred, truth, intens_pred, intens_true)
     assert set(
         [
             "track_error",
+            "track_rmse",
             "along_track_error",
             "cross_track_error",
             "intensity_mae",
+            "intensity_rmse",
             "rapid_intensification_skill",
         ]
     ) <= set(results.keys())
     assert results["intensity_mae"] == pytest.approx(3.3333, rel=1e-4)
+    assert results["intensity_rmse"] == pytest.approx(expected_intensity_rmse, rel=1e-4)
     assert results["rapid_intensification_skill"] == pytest.approx(2 / 3, rel=1e-4)
+    assert results["track_rmse"] == pytest.approx(expected_track_rmse, rel=1e-4)
 
 
 def test_rapid_intensification_skill_no_events_or_short_seq():


### PR DESCRIPTION
## Summary
- add `track_rmse` and `intensity_rmse` metrics with root-mean-square logic
- wire new metrics into config and metric registry
- test RMSE metrics on synthetic data

## Testing
- `pre-commit run --files configs/default_config.yaml src/galenet/evaluation/metrics.py tests/test_evaluation_metrics.py`
- `pytest tests/test_evaluation_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79981b4b08326a6afea5552a329df